### PR TITLE
fix: bump quixit to v0.14.11 (auth callback fix)

### DIFF
--- a/apps/filebrowser/grassnose-media.yml
+++ b/apps/filebrowser/grassnose-media.yml
@@ -1,0 +1,154 @@
+---
+# grassnose-media — tiny read-only nginx pod that serves the specific
+# audio/video files referenced by https://github.com/ianhundere/grassnose_blog
+# publicly via Tailscale Funnel.
+#
+# Design notes:
+# - Lives in the filebrowser namespace so it can mount the same RWX PVC
+#   (filebrowser) that backs the NFS share — no data duplication, no
+#   cross-namespace PV plumbing.
+# - Mounts ONLY `files/grassnose_public/` (via subPath), never the broader
+#   host_songs/host_videos dirs. That subdir contains only the files you've
+#   intentionally chosen to publish. Any other file on the share is invisible
+#   to this pod.
+# - Uses nginx-unprivileged so the container runs as non-root (uid 101).
+# - Funnel is requested via Service annotation; the Tailscale operator
+#   provisions a proxy and exposes the service at
+#   `grassnose-media.<tailnet>.ts.net` over public HTTPS (Let's Encrypt cert
+#   handled entirely by Tailscale — no cert-manager involvement).
+#
+# Pre-reqs (do these ONCE in the Tailscale admin console before deploying):
+#   1. Tailnet Settings → Funnel → enable the feature if not already on.
+#   2. Access controls → ACLs: ensure the tag used by the operator-managed
+#      proxies has `funnel` in nodeAttrs, e.g.
+#        "nodeAttrs": [{ "target": ["tag:k8s"], "attr": ["funnel"] }]
+#   3. Populate /srv/grassnose_public with the 7 blog files (see README
+#      comment at bottom of this file for copy commands).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grassnose-media-nginx
+  namespace: filebrowser
+  labels:
+    app: grassnose-media
+data:
+  default.conf: |
+    server {
+      listen 8080 default_server;
+      server_name _;
+
+      # no directory listing — only explicit filenames are reachable
+      autoindex off;
+
+      # these files are immutable; let clients + any caches hold on to them
+      add_header Cache-Control "public, max-age=31536000, immutable" always;
+
+      # HTTP range requests work out of the box for static files, so audio
+      # scrubbing / video seeking "just works" in HTML5 players.
+
+      # liveness/readiness probe target — returns 200 regardless of
+      # whether media files are present yet
+      location = /healthz {
+        access_log off;
+        add_header Cache-Control "no-store" always;
+        return 200 "ok\n";
+      }
+
+      # /songs/*.mp3 → /usr/share/nginx/html/songs/*.mp3
+      location /songs/ {
+        alias /usr/share/nginx/html/songs/;
+        try_files $uri =404;
+      }
+      # /videos/*.mp4 → /usr/share/nginx/html/videos/*.mp4
+      location /videos/ {
+        alias /usr/share/nginx/html/videos/;
+        try_files $uri =404;
+      }
+
+      # everything else: 404. no welcome page, no /, no nginx index.
+      location = / { return 404; }
+      location / { return 404; }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grassnose-media
+  namespace: filebrowser
+  labels:
+    app: grassnose-media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: grassnose-media
+  template:
+    metadata:
+      labels:
+        app: grassnose-media
+    spec:
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.29-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 32Mi
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+            - name: filebrowser-data
+              mountPath: /usr/share/nginx/html/songs
+              subPath: files/grassnose_public/songs
+              readOnly: true
+            - name: filebrowser-data
+              mountPath: /usr/share/nginx/html/videos
+              subPath: files/grassnose_public/videos
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 3
+            periodSeconds: 5
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: grassnose-media-nginx
+        - name: filebrowser-data
+          persistentVolumeClaim:
+            claimName: filebrowser
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grassnose-media
+  namespace: filebrowser
+  labels:
+    app: grassnose-media
+  annotations:
+    # Tailscale operator picks this up and provisions a Funnel proxy.
+    # Public URL becomes: https://grassnose-media.<tailnet>.ts.net
+    tailscale.com/hostname: "grassnose-media"
+    tailscale.com/funnel: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: grassnose-media

--- a/apps/filebrowser/kustomization.yml
+++ b/apps/filebrowser/kustomization.yml
@@ -8,3 +8,4 @@ resources:
   - service.yml
   - pvc.yml
   - gateway.yml
+  - grassnose-media.yml

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.14.10 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.14.11 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/ianhundere/quixit` from `0.14.10` → `0.14.11`
- Ships the OAuth callback fix that auto-reactivates soft-deleted users on re-login + friendlier error-code UX

## Upstream
- Quixit PR: ianhundere/quixit#78
- Release: https://github.com/ianhundere/quixit/releases/tag/v0.14.11
- Image verified at `ghcr.io/ianhundere/quixit:0.14.11` (digest `sha256:8fea4d43...`)

## Test plan
- [ ] Merge triggers Flux reconcile on next interval (<1 min)
- [ ] `kubectl -n quixit rollout status deploy/quixit` reports Available
- [ ] `https://quixit.us/api/health` returns 200
- [ ] Test soft-deleted user re-login against prod (the original bug) — no more "Token exchange failed" loop