### PR TITLE
fix: bump tufkin to v0.19.1 (Go 1.26.2 stdlib CVEs)

### DIFF
--- a/apps/tufkin/deployment.yml
+++ b/apps/tufkin/deployment.yml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-secret
       initContainers:
         - name: migrate
-          image: ghcr.io/ianhundere/tufkin:0.19.0
+          image: ghcr.io/ianhundere/tufkin:0.19.1
           command: ["/usr/local/bin/migrate"]
           args:
             - "-path"
@@ -38,7 +38,7 @@ spec:
                   key: db-password
       containers:
         - name: tufkin
-          image: ghcr.io/ianhundere/tufkin:0.19.0
+          image: ghcr.io/ianhundere/tufkin:0.19.1
           ports:
             - containerPort: 8080
           envFrom:


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/ianhundere/tufkin` from `0.19.0` → `0.19.1` on both the migrate initContainer and the main container
- Ships Go 1.26.1 → 1.26.2 stdlib CVE fixes

## Upstream
- Original Go bump: ianhundere/tufkin#87 (landed as `ci:` — didn't trigger release-please)
- Release cut: ianhundere/tufkin#88 → release-please PR #89 → GoReleaser
- Release: https://github.com/ianhundere/tufkin/releases/tag/v0.19.1
- Image verified at `ghcr.io/ianhundere/tufkin:0.19.1` (digest `sha256:3dbc17d6...`)

## Test plan
- [ ] Merge triggers Flux reconcile
- [ ] `kubectl -n tufkin rollout status deploy/tufkin` reports Available
- [ ] `https://auth.clusterian.pw/api/health` returns 200
- [ ] quixit OAuth login still works end-to-end against refreshed tufkin