### PR TITLE
fix: bump quixit to 0.15.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.14.11 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.15.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

Bumps `apps/quixit/deployment.yml` from `0.14.11` → `0.15.0`.

Release notes: https://github.com/ianhundere/quixit/releases/tag/v0.15.0

## Test plan

- [x] GHCR tag `ghcr.io/ianhundere/quixit:0.15.0` exists (verified)
- [ ] After merge: `flux reconcile kustomization flux-system --with-source`
- [ ] Verify rollout: `kubectl -n quixit rollout status deploy/quixit`
- [ ] Smoke-test https://quixit.us/archive/:id with a long-description song — expand/collapse works