### PR TITLE
fix: bump quixit to v0.16.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.15.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.16.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps quixit image to `0.16.0` — cycle Play-All queue + audio scrubber precision fix (ianhundere/quixit#84).

## Test plan

- [ ] After merge, `flux reconcile kustomization flux-system --with-source`
- [ ] Verify `kubectl -n quixit get deploy quixit -o jsonpath='{.spec.template.spec.containers[0].image}'` reports `0.16.0`
- [ ] Smoke-test `https://quixit.us/archive/:id` — Play-All button present on a cycle with submissions; scrubber behaves on a long track