### PR TITLE
fix: bump quixit to v0.17.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.16.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.17.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps quixit image to `0.17.0` — cycle-queue controls in MiniPlayer (prev/next/stop + position) (ianhundere/quixit#86).

## Test plan

- [ ] After merge, `flux reconcile kustomization apps --with-source`
- [ ] `kubectl -n quixit get deploy quixit -o jsonpath='{.spec.template.spec.containers[0].image}'` reports `0.17.0`
- [ ] Smoke-test `https://quixit.us/archive/:id` — click Play All, verify MiniPlayer queue-mode controls (prev/next/stop + "N of M")