### PR TITLE
fix: dedicate HTTPRoute rule for /api/sse with no request timeout

### DIFF
--- a/apps/quixit/gateway.yml
+++ b/apps/quixit/gateway.yml
@@ -30,6 +30,37 @@ spec:
     namespace: envoy-gateway-system
     sectionName: quixit-us-https
   rules:
+  # SSE long-poll: Envoy's default route timeout (15s) was killing the
+  # /api/sse stream before even the first keepalive (20s). timeouts.request:
+  # "0s" disables the request timeout for this path only — all other
+  # requests keep the default. Note: the BackendTrafficPolicy below still
+  # applies connectionIdleTimeout: 600s / maxConnectionDuration: 600s to
+  # this route, so the stream is "long but not infinite" — capped at 10min.
+  # Client auto-reconnects on drop.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api/sse
+    timeouts:
+      request: "0s"
+      backendRequest: "0s"
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        add:
+        - name: Strict-Transport-Security
+          value: "max-age=31536000; includeSubDomains; preload"
+        - name: Access-Control-Allow-Origin
+          value: "*"
+        - name: Access-Control-Allow-Credentials
+          value: "true"
+        - name: Referrer-Policy
+          value: "strict-origin-when-cross-origin"
+        - name: X-Content-Type-Options
+          value: "nosniff"
+    backendRefs:
+    - name: quixit
+      port: 8080
   - matches:
     - path:
         type: PathPrefix


### PR DESCRIPTION
## Summary

Fixes the Live Activity feed's SSE stream being killed every 15s by Envoy's default route timeout. Adds a path-prefix rule for `/api/sse` with `timeouts.request: "0s"` and `timeouts.backendRequest: "0s"`, scoped to that path only — all other routes keep the default. Mirrors a minimal set of CORS/HSTS headers from the catch-all rule so the SSE path doesn't look header-bare to scanners.

The companion backend PR (ianhundere/quixit#88) adds persistence + backfill so the feed is useful even during the narrow reconnect windows, but the timeout fix is what makes SSE actually stay up.

## Test plan

- [ ] After merge: `flux reconcile kustomization apps --with-source`
- [ ] `curl -sN https://quixit.us/api/sse` (as an authenticated user via cookie) stays open past 20s
- [ ] `kubectl -n quixit logs deploy/quixit --tail=50 | grep /api/sse` shows `duration_ms` values well beyond 15000ms