### PR TITLE
fix: bump quixit to v0.18.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.17.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.18.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps quixit image to `0.18.0` — Live Activity feed persistence + backfill (ianhundere/quixit#88).
- Requires the SSE gateway fix (rpi-k3s #19, already merged) for the feed to stay connected past 15s.

## Test plan

- [ ] After merge, `flux reconcile kustomization apps --with-source`
- [ ] `kubectl -n quixit get deploy quixit -o jsonpath='{.spec.template.spec.containers[0].image}'` reports `0.18.0`
- [ ] Health endpoint reports `version:0.18.0`
- [ ] Smoke-test `https://quixit.us/` logged in — Live Activity feed loads with history; SSE `/api/sse` request stays open >30s in DevTools.