### PR TITLE
fix: bump quixit to v0.20.0

### DIFF
--- a/apps/media/lidarr/lidarr.deployment.yml
+++ b/apps/media/lidarr/lidarr.deployment.yml
@@ -42,7 +42,7 @@ spec:
           value: lidarr-main
         - name: LIDARR__POSTGRES__LOGDB
           value: lidarr-log
-        image: linuxserver/lidarr:2.14.5 # {"$imagepolicy": "flux-system:lidarr"}
+        image: linuxserver/lidarr:3.1.0 # {"$imagepolicy": "flux-system:lidarr"}
         imagePullPolicy: IfNotPresent
         name: lidarr
         ports:

--- a/apps/media/lidarr/lidarr.deployment.yml
+++ b/apps/media/lidarr/lidarr.deployment.yml
@@ -42,7 +42,7 @@ spec:
           value: lidarr-main
         - name: LIDARR__POSTGRES__LOGDB
           value: lidarr-log
-        image: linuxserver/lidarr:2.11.2 # {"$imagepolicy": "flux-system:lidarr"}
+        image: linuxserver/lidarr:2.14.5 # {"$imagepolicy": "flux-system:lidarr"}
         imagePullPolicy: IfNotPresent
         name: lidarr
         ports:

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.18.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.19.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.19.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.19.1 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.19.1 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.20.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.16.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.17.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.15.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.16.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.17.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.18.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- Deploys quixit v0.20.0 — includes Epic 10 (stories 10-1 through 10-5):
  - feat(10-1): quarantine cascade to activity feed
  - feat(10-2): edit own song submission
  - feat(10-3): 24h phase-transition reminder email
  - docs(10-4): auth domain migration (infra cutover executed 2026-04-19)
  - chore(10-5): tech-debt sweep — ExpandableText + activity-feed leftovers
- Quixit release: https://github.com/ianhundere/quixit/releases/tag/v0.20.0

## Test plan
- [x] GoReleaser built + pushed ghcr.io/ianhundere/quixit:0.20.0
- [x] flux-image-updates branch verified (clean 0.19.1 → 0.20.0 diff on apps/quixit/deployment.yml)
- [ ] Merge this PR → Flux reconciles apps → rollout quixit deploy
- [ ] Verify quixit.us responds + /api/auth/me works post-rollout