### PR TITLE
fix: bump quixit to v0.20.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.19.1 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.20.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
Deploys quixit v0.20.0 — Epic 10 (5 stories). Release: https://github.com/ianhundere/quixit/releases/tag/v0.20.0

- feat(10-1): quarantine cascade to activity feed
- feat(10-2): edit own song submission
- feat(10-3): 24h phase-transition reminder email
- docs(10-4): auth domain migration (infra cutover already executed 2026-04-19)
- chore(10-5): tech-debt sweep

## Test plan
- [x] GoReleaser built + pushed ghcr.io/ianhundere/quixit:0.20.0
- [ ] Flux reconciles → pods roll over
- [ ] quixit.us responds + /api/auth/me works post-rollout