### PR TITLE
fix(quixit): SMTP_FROM → noreply@quixit.us

### DIFF
--- a/apps/quixit/configmap.yml
+++ b/apps/quixit/configmap.yml
@@ -45,4 +45,4 @@ data:
   SMTP_HOST: "smtp.resend.com"
   SMTP_PORT: "587"
   SMTP_USER: "resend"
-  SMTP_FROM: "noreply@auth.quixit.us"
+  SMTP_FROM: "noreply@quixit.us"

--- a/apps/quixit/configmap.yml
+++ b/apps/quixit/configmap.yml
@@ -45,4 +45,4 @@ data:
   SMTP_HOST: "smtp.resend.com"
   SMTP_PORT: "587"
   SMTP_USER: "resend"
-  SMTP_FROM: "noreply@clusterian.pw"
+  SMTP_FROM: "noreply@auth.quixit.us"


### PR DESCRIPTION
## Summary
Resend 403s all sends because `clusterian.pw` is no longer a verified sending domain. Switch to `noreply@quixit.us`.

## Context
- Auth migrated from `auth.clusterian.pw` → `auth.quixit.us` on 2026-04-19.
- `SMTP_FROM` in `apps/quixit/configmap.yml` was overlooked in that migration.
- v0.20.0 reminder dispatch today fired 9 sends; all returned `403 Domain not verified` from Resend.
- **Verified domain in Resend is `quixit.us` (root), not `auth.quixit.us` subdomain** — Resend verification is per-exact-domain.

## Test plan
- [x] Verify `quixit.us` as a sending domain in Resend (DKIM + Return-Path records).
- [ ] Merge this PR.
- [ ] `flux reconcile kustomization apps` → `kubectl -n quixit rollout restart deploy/quixit` (ConfigMap env isn't auto-reloaded).
- [ ] Check Resend Logs: next `POST /emails` should return 200.