### PR TITLE
fix: bump quixit to v0.20.1

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.20.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.20.1 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
Deploys quixit v0.20.1 — post-review polish on v0.20.0's reminder email.

- fix: subject/H2 → "Samples/Songs phase ending soon" (was literal "ends in 24 hours"; window fires whenever `phase_end ∈ (now, now+24h]`, so shortened cycles saw wrong subject).
- fix: "Cycle #2: Cycle #2" redundancy for cycles without custom titles — template now conditionally renders the colon+title only when Title is non-empty and non-redundant.

Release: https://github.com/ianhundere/quixit/releases/tag/v0.20.1

## Test plan
- [x] GoReleaser built + pushed ghcr.io/ianhundere/quixit:0.20.1
- [ ] Flux reconciles → pods roll
- [ ] Manual verify on next natural reminder (already sent today at 19:30; no need to force-refire — users already got today's reminder with the fixed SMTP_FROM).