### PR TITLE
fix: bump quixit to v0.21.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.20.2 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.21.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps quixit image to **v0.21.0** which adds the IRC chat bridge to Libera.Chat #quixit (PR ianhundere/quixit#103).

**This PR is image-bump only — the chat feature is gated off in prod until a follow-up PR wires `IRC_*` env vars in `configmap.yml` and `IRC_SASL_PASSWORD` in `quixit-credentials`.** The /chat route will render a "Chat is currently disabled" placeholder until then. Existing functionality is unchanged.

Branch is fresh from `main` per the standard rpi-k3s deploy convention.