### PR TITLE
feat(quixit): enable IRC chat bridge to Libera #quixit

### DIFF
--- a/apps/quixit/configmap.yml
+++ b/apps/quixit/configmap.yml
@@ -46,3 +46,13 @@ data:
   SMTP_PORT: "587"
   SMTP_USER: "resend"
   SMTP_FROM: "noreply@quixit.us"
+
+  # IRC chat bridge — relays messages between /chat and Libera #quixit via the
+  # quixit-bot NickServ account. SASL password sourced from quixit-credentials.
+  IRC_ENABLED: "true"
+  IRC_SERVER: "irc.libera.chat:6697"
+  IRC_NICK: "quixit-bot"
+  IRC_CHANNEL: "#quixit"
+  IRC_SASL_USER: "quixit-bot"
+  IRC_RATE_LIMIT_PER_MIN: "5"
+  IRC_RATE_LIMIT_PER_HOUR: "20"

--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -67,6 +67,12 @@ spec:
                   name: quixit-credentials
                   key: smtp-password
                   optional: true
+            - name: IRC_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: quixit-credentials
+                  key: irc-sasl-password
+                  optional: true
           volumeMounts:
             - name: quixit-storage
               mountPath: /var/quixit

--- a/apps/quixit/secret.yml
+++ b/apps/quixit/secret.yml
@@ -8,3 +8,4 @@ stringData:
   db-password: ${QUIXIT_PW}
   session-secret: ${QUIXIT_SESSION_SECRET}
   smtp-password: ${TUFKIN_SMTP_PASSWORD}
+  irc-sasl-password: ${IRC_SASL_PW}


### PR DESCRIPTION
Stage 2 of the IRC chat rollout. Flips the feature flag on and wires SASL credentials.

## Pre-requisite (already done)
- `IRC_SASL_PW` added to `config/cluster-secrets.enc.yaml` and server-side applied to the cluster (`secret/cluster-secrets serverside-applied`). Flux's postBuild substitution uses it to render `quixit-credentials.irc-sasl-password`.

## Effect after merge + reconcile
- `quixit-credentials` Secret gains key `irc-sasl-password`
- `quixit-config` ConfigMap gains all `IRC_*` keys
- Deployment rolls (configmap + env ref are both pod-spec inputs)
- Bot connects to `irc.libera.chat:6697`, SASLs as `quixit-bot`, joins `#quixit`
- /chat live indicator turns green