### PR TITLE
fix: bump quixit to v0.21.1

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.21.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.21.1 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps quixit image to **v0.21.1**. Adds two small bot-identity signals on the IRC bridge:

- Self-set Libera user mode `+B` after connect so bot-aware clients (TheLounge, gamja, weechat with `bots.py`) render the bot indicator and skip it for activity counters
- Descriptive `RealName` so `/whois quixit-bot` identifies the bridge and links back to https://quixit.us

No env/config changes; pure image swap. ChanServ `+V` flag for `#quixit` was set out-of-band so the bot will gain `+v` on the next reconnect (which happens on this rollout).