### PR TITLE
fix: bump quixit to v0.21.2

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.21.1 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.21.2 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps quixit image to **v0.21.2**.

Resolves the silent IRC outage we hit during the v0.21.1 rolling deploy: the new pod's initial \`Connect()\` now retries with backoff (5s / 15s / 30s / 60s / 120s) so Libera's nick-release window after the old pod's QUIT is absorbed automatically. \`Stop()\` short-circuits the retry loop so shutdown stays prompt.

No env/config changes; pure image swap.