### PR TITLE
fix: bump quixit to v0.21.3

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.21.2 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.21.3 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps quixit deployment image to `ghcr.io/ianhundere/quixit:0.21.3`.
- Carries the chat composer focus fix — textarea no longer disables (and blurs) on transient SSE reconnects.

## Test plan

- [ ] Flux reconciles `apps/quixit` after merge
- [ ] New pod rolls out with `image: ghcr.io/ianhundere/quixit:0.21.3`
- [ ] `/chat` on quixit.us — typing through a brief connection blip preserves textarea focus and caret position