### PR TITLE
feat: bump quixit to v0.22.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.21.3 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.22.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps quixit deployment image to `ghcr.io/ianhundere/quixit:0.22.0`.
- Bundles two Epic 11 stories shipped on 2026-05-07:
  - **11.4** — admin UI cycle deadline editing (PATCH `samples_end_at`/`songs_end_at`, ordering + phase-state validation, audit log)
  - **11.5** — chat composer UX polish (contextual blocker hint, auto-recover from CHAT_DISABLED)

## Test plan

- [ ] Flux reconciles `apps/quixit` after merge
- [ ] New pod rolls out with `image: ghcr.io/ianhundere/quixit:0.22.0`
- [ ] `/api/health` reports `version: 0.22.0`
- [ ] Manual: edit a cycle's `songs_end_at` via admin UI; confirm DB row + audit log
- [ ] Manual: chat composer over-limit + offline hint visible; CHAT_DISABLED auto-recovers on focus