### PR TITLE
deploy(tufkin): bump to v0.20.0

### DIFF
--- a/apps/tufkin/deployment.yml
+++ b/apps/tufkin/deployment.yml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-secret
       initContainers:
         - name: migrate
-          image: ghcr.io/ianhundere/tufkin:0.19.1
+          image: ghcr.io/ianhundere/tufkin:0.20.0
           command: ["/usr/local/bin/migrate"]
           args:
             - "-path"
@@ -38,7 +38,7 @@ spec:
                   key: db-password
       containers:
         - name: tufkin
-          image: ghcr.io/ianhundere/tufkin:0.19.1
+          image: ghcr.io/ianhundere/tufkin:0.20.0
           ports:
             - containerPort: 8080
           envFrom:


### PR DESCRIPTION
## Summary
Bumps `apps/tufkin/deployment.yml` from `0.19.1` → `0.20.0`. Both `migrate` initContainer and `tufkin` container point at the new tag.

Releases Epic 15 (Deferred Work Cleanup) from tufkin:
- **15.1** identity: provider concurrency, lifecycle & rotation observability ([#91](https://github.com/ianhundere/tufkin/pull/91))
- **15.2** attest,config,oauth: validator & config correctness fixes ([#93](https://github.com/ianhundere/tufkin/pull/93))
- **15.3** conformance: validate metadata issuer matches server URL ([#94](https://github.com/ianhundere/tufkin/pull/94))
- **15.4** conformance: security & robustness hardening ([#95](https://github.com/ianhundere/tufkin/pull/95))
- **15.5** conformance,identity: close NFR test-coverage gaps ([#96](https://github.com/ianhundere/tufkin/pull/96))
- **15.6** conformance,attest: documentation polish ([#97](https://github.com/ianhundere/tufkin/pull/97))

Server-affecting changes are 15.1 (RotatableProvider concurrency, lifecycle, observability metrics), 15.2 (validator/config correctness), and 15.6 (SuiteSummary JSON tag — internal only). The conformance suite hardening lands in the bundled tufkin-conformance CLI; the production auth server image picks up the identity + validator improvements.

Backward-compatible: no schema, config, or OAuth wire changes. quixit (v0.14.11) requires zero changes.

## Test plan
- [ ] Flux reconciles `apps/tufkin/` after merge
- [ ] tufkin pod restarts successfully on the 0.20.0 image
- [ ] `https://auth.clusterian.pw/api/health` returns 200
- [ ] `https://auth.clusterian.pw/.well-known/oauth-authorization-server` returns valid metadata with `issuer` matching base URL
- [ ] `https://auth.clusterian.pw/.well-known/jwks.json` returns valid JWKS
- [ ] quixit OAuth login flow continues to work end-to-end