### PR TITLE
feat: bump quixit to v0.23.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.22.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.23.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps quixit deployment image to `ghcr.io/ianhundere/quixit:0.23.0`.
- Bundles four Epic 11 stories shipped on 2026-05-08:
  - **11.2** — activity feed defensive read-path filter for quarantined entities (LEFT JOIN against samples/submissions in ListEvents)
  - **11.1c** — chat audit completeness on idempotent re-hide + drop unused `idx_chat_messages_created_at` (migration 000019)
  - **11.1a** — IRC bridge concurrency hardening (echo-suppression ring, atomic ChatPostLimiter Reserve/Cancel, Send retry, Stop lock-release-before-Quit, Loop goroutine join)
  - **11.1b** — chat abuse + impersonation hardening (per-user SSE cap, inbound PRIVMSG flood guard, impersonation prefix sanitize with unicode + full-width bracket support, chatDisplayNick fallback `quixit-user`)

## Test plan

- [ ] Flux reconciles `apps/quixit` after merge
- [ ] New pod rolls out with `image: ghcr.io/ianhundere/quixit:0.23.0`
- [ ] Migration 000019 (drop `idx_chat_messages_created_at`) runs cleanly at pod start
- [ ] `/api/health` reports `version: 0.23.0`
- [ ] IRC bridge connects to `#quixit` cleanly post-rollout (no stuck-loop warning, no scrollback divergence on first inbound)
- [ ] `/chat`: post a message; verify it lands on Libera + activity feed; quarantine a sample/submission via admin and verify it disappears from activity feed without reload