### PR TITLE
feat: bump quixit to v0.24.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.23.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.24.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

Bumps `apps/quixit/deployment.yml` image tag from `0.23.0` → `0.24.0`.

### What's in v0.24.0

- **feat(activity-feed):** scale + test-hygiene sweep — JSONB type fidelity, type CHECK + index, optional retention service (Story 11.3, ianhundere/quixit#122)
  - `ListRecent` JSONB decoder switched to `UseNumber()` + `normalizeJSONNumbers` so integer payloads come back as `int64` (matches writer-side `Create`); fixes backfill-vs-live-SSE type drift
  - Migration `000020`: `activity_events_type_check` CHECK constraint + `idx_activity_events_type` btree index; pre-validation aggregates offending rows in `DO $$ ... RAISE EXCEPTION` so deploy-time mismatches fail loudly
  - New `ActivityRetentionService` gated by `ACTIVITY_RETENTION_DAYS` (default `0` = disabled, no goroutine, no log noise); hourly `DELETE older than N days` with `slog.Info("activity: retention sweep", "deleted", n, "days", N)` per run
  - `useEventSource` synchronous-during-close gen-counter gate test-pinned (mutation-tested)
  - `warnSchedulerDisabled` extracted from `main.go` into its own helper + unit test
  - `activity_event_repository_test` cardinality tightened (`assert.Len` + explicit `created_at` overrides; no `time.Sleep`)

### Risk

Low. JSONB serialization shape changes are the only behavioral diff visible to clients — and integer fields were the only ones drifting; string/boolean payloads are byte-identical to v0.23.0. Retention service is off by default.

### Post-merge

Flux reconciles `apps` → rolls the quixit deployment to v0.24.0. Watch:
- `kubectl -n quixit rollout status deploy/quixit`
- New `activity_events` rows render integer fields as ints in `/api/activity/recent` JSON
- No `activity: retention sweep` log lines (ACTIVITY_RETENTION_DAYS not yet set)

## Test plan
- [x] Image `ghcr.io/ianhundere/quixit:0.24.0` published (Release workflow run 25589384986 succeeded)
- [x] Single-line bump; no ConfigMap/Secret/Gateway changes alongside
- [ ] Post-merge: Flux reconcile succeeds; rollout progresses; `/api/health` returns 200 on the new revision