### PR TITLE
feat: bump quixit to v0.25.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.24.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.25.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- Bumps `apps/quixit/deployment.yml` image tag from `0.24.0` → `0.25.0`.
- Picks up quixit v0.25.0 (https://github.com/ianhundere/quixit/releases/tag/v0.25.0):
  - `feat(audio-player): remove playback-speed control` (ianhundere/quixit#124)
  - `feat(scheduler): 5-min ticker + edit-triggered transition fast path` (ianhundere/quixit#125)

## Test plan
- [ ] Flux reconciles `apps/quixit` and the deployment rolls out
- [ ] `kubectl -n quixit get pods` shows the new replicas running `:0.25.0`
- [ ] Verify quixit.us responds 200 and the scheduler logs `"Cycle scheduler started" interval=5m0s`
- [ ] Smoke-test admin PATCH of a cycle deadline and confirm `"Cycle transitioned"` log lands within seconds (fast path)