### PR TITLE
feat: bump quixit to v0.26.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.25.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.26.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps quixit from v0.25.0 → v0.26.0.

## What's in v0.26.0

- **12.1** — per-(admin, route) write-endpoint rate limiter
- **12.2** — audit-log completeness & failure visibility
- **12.3** — audit-log queryability for IRC-bridged moderation
- **12.4** — admin cycle deadline-edit polish (NothingToUpdate guard, timezone trim, untouched-field snapshot)
- **12.5** — SAMPLES-phase extension via songs_start_at editing

## Deploy

Merge this PR → Flux reconciles → rolling update.