### PR TITLE
feat: bump tufkin to v0.20.1

### DIFF
--- a/apps/tufkin/deployment.yml
+++ b/apps/tufkin/deployment.yml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-secret
       initContainers:
         - name: migrate
-          image: ghcr.io/ianhundere/tufkin:0.20.0
+          image: ghcr.io/ianhundere/tufkin:0.20.1
           command: ["/usr/local/bin/migrate"]
           args:
             - "-path"
@@ -38,7 +38,7 @@ spec:
                   key: db-password
       containers:
         - name: tufkin
-          image: ghcr.io/ianhundere/tufkin:0.20.0
+          image: ghcr.io/ianhundere/tufkin:0.20.1
           ports:
             - containerPort: 8080
           envFrom:


### PR DESCRIPTION
## Summary

Bumps tufkin from v0.20.0 → v0.20.1 in `apps/tufkin/deployment.yml`. Updates both image refs (initContainer `migrate` + main `tufkin` container).

## What's in v0.20.1

Epic 16 — provider hardening + conformance robustness. 6 PRs bundled:

- #98 — authentication & credential robustness
- #100 — SIGHUP debounce cap + identical-key rotation rejection
- #101 — HTTP-client input validation + error diagnostics
- #102 — parseOAuthError overflow message + 16-3 test hardening
- #103 — test quality & boundary coverage (lazy-clear export hook, mock gracePeriod settable, grace-period boundary tests, interface{}→any, errors.As URL parse)
- #104 — final review followups (>= 1 lazyClearCount, t.Fatalf for errors.As, +0ns boundary probe pinning strict `>`, key-identity verification)

Release notes: https://github.com/ianhundere/tufkin/releases/tag/v0.20.1

## Test plan

- [x] Image `ghcr.io/ianhundere/tufkin:0.20.1` published as multi-arch (amd64 + arm64)
- [x] Both `image:` refs in `deployment.yml` updated consistently
- [ ] After merge: flux reconciles, k3s rolls deployment, pod transitions to v0.20.1 with no migration errors
- [ ] Verify `auth.clusterian.pw/.well-known/oauth-authorization-server` reachable post-rollout