### PR TITLE
fix(envoy-gateway): raise memory limits + bump to v1.8.0

### DIFF
--- a/infrastructure/envoy-gateway/envoyproxy.yml
+++ b/infrastructure/envoy-gateway/envoyproxy.yml
@@ -21,8 +21,15 @@ spec:
             requests:
               memory: "256Mi"
               cpu: "50m"
+            # Limit raised from 256Mi → 1Gi after a 33-day Envoy data-plane
+            # crashloop traced to TCMalloc CHECK failure (exit 133) under
+            # cgroup memory pressure. Fresh-pod baseline is ~50Mi but Envoy's
+            # internal counters / connection pools / leaks grow over weeks; the
+            # 256Mi ceiling left no headroom for TCMalloc arena expansion and
+            # the allocator aborted rather than retried. 1Gi gives multi-month
+            # headroom without crowding the amd64 worker node it lands on.
             limits:
-              memory: "256Mi"
+              memory: "1Gi"
       envoyService:
         externalTrafficPolicy: Local
         # In merged-gateway mode, the per-Gateway `metallb` annotation on

--- a/infrastructure/envoy-gateway/release.yml
+++ b/infrastructure/envoy-gateway/release.yml
@@ -25,5 +25,11 @@ spec:
           requests:
             memory: 256Mi
             cpu: 50m
+          # Control-plane limit raised from 256Mi → 512Mi as a defensive
+          # parity move after the data-plane (envoyproxy.yml) hit a
+          # cgroup-pressure crash at its 256Mi ceiling. Controller current
+          # usage is ~75Mi steady-state — far less leaky than the data
+          # plane — but the same failure pattern is theoretically reachable
+          # over long uptime, and 512Mi cheaply removes that risk.
           limits:
-            memory: 256Mi
+            memory: 512Mi

--- a/infrastructure/sources/envoy-gateway-oci.yml
+++ b/infrastructure/sources/envoy-gateway-oci.yml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://docker.io/envoyproxy/gateway-helm
   ref:
-    tag: v1.7.1
+    tag: v1.8.0


### PR DESCRIPTION
## Root cause

The 2026-05-14 outage where quixit.us + auth.quixit.us went down for several minutes traced to the Envoy data-plane pod (`envoy-eg-d8c59e83-*`) crashlooping after **33 days of uptime** with container exit code **133** (TCMalloc internal CHECK failure).

Initial diagnosis suspected ARM64 + TCMalloc virtual-address-space exhaustion, but the affected pod runs on **`kube-worker4` (amd64)**, ruling that out. Real cause: **cgroup memory pressure against the 256Mi limit**. Fresh-pod RSS baseline is ~50Mi, but Envoy's internal stats counters, connection pool state, and buffers grow over weeks until TCMalloc's attempt to expand an allocator arena triggers a CHECK abort under the cap.

## Changes

| File | Before | After | Why |
|---|---|---|---|
| `infrastructure/envoy-gateway/envoyproxy.yml` | data-plane `limits.memory: 256Mi` | `1Gi` | Matches upstream EnvoyProxy customization-doc example. Request unchanged at 256Mi for predictable scheduling. |
| `infrastructure/envoy-gateway/release.yml` | control-plane `limits.memory: 256Mi` | `512Mi` | Defensive parity. Current usage ~75Mi (6× headroom) but same failure pattern is theoretically reachable. |
| `infrastructure/sources/envoy-gateway-oci.yml` | helm chart `v1.7.1` | `v1.8.0` | v1.8.0 ships **deferred stat creation** — only initializes the subset of metrics actually used at runtime, directly addressing the slow-growth memory pattern that caused this outage. |

## v1.8.0 breaking-change audit

Upstream release notes flag four behavior changes. Verified none affect this repo (`grep -rn ... infrastructure/`):

- `samplingFraction` semantics — not used
- `SecurityPolicy 0s` timeout — not used (no SecurityPolicy resources)
- Controller JSON log encoder — cosmetic
- OAuth2 filter restructure — only affects EnvoyPatchPolicy users; we have none

## Deploy + verify

After merge, Flux will reconcile within 30min (or trigger manually via `flux reconcile source git flux-system && flux reconcile kustomization infrastructure`). Watch:

```bash
kubectl get pods -n envoy-gateway-system -w
# Both pods should reach 2/2 (data-plane) and 1/1 (controller) and stay there.
kubectl describe pod -n envoy-gateway-system <data-plane-pod> | grep -A1 "Limits:"
# Confirm "memory: 1Gi" on data-plane container.
```

## Recurrence projection

Previous failure interval: **33 days from clean start → crash**. With 4× the memory ceiling and v1.8.0's stat-creation reduction, the next analogous failure should be deferred by at minimum several months, more likely indefinitely. If it does recur, the fix path is the same single-pod delete that would have resolved this incident in seconds.