### PR TITLE
feat(envoy-gateway): weekly data-plane pod rotation CronJob

### DIFF
--- a/infrastructure/envoy-gateway/cronjob-rotate.yml
+++ b/infrastructure/envoy-gateway/cronjob-rotate.yml
@@ -1,0 +1,105 @@
+---
+# Weekly rotation of the Envoy data-plane pod. Belt-and-suspenders for the
+# TCMalloc-under-cgroup-pressure failure mode that took down quixit.us +
+# auth.quixit.us on 2026-05-14 after 33 days of pod uptime.
+#
+# Why this exists even though we raised the memory limit and bumped Envoy
+# Gateway: the underlying failure mode is unbounded allocator drift over time.
+# 4× memory headroom + v1.8.0's deferred stat creation push the natural
+# failure interval out to many months, but never to zero. A scheduled weekly
+# pod recycle resets allocator state before the ceiling can be approached.
+#
+# Design choices, each load-bearing:
+#
+# 1. `kubectl delete pod` (not `rollout restart`) — Flux ignores pod-level
+#    operations. The 2026-05-14 cascade was caused by `rollout restart`
+#    adding a `kubectl.kubernetes.io/restartedAt` annotation, which Flux
+#    reverted on next reconcile, triggering wave-2 restarts of everything.
+#    Pod deletion is invisible to Flux.
+#
+# 2. Sunday 10:00 UTC = 03:00 PDT — verified dead window for quixit's user
+#    base (US-centric, small community). The 5-min scheduler ticker is
+#    24/7 but absorbs a 5-10s API blip without issue (next tick picks up).
+#    Cycle phase transitions are admin-set times; nothing fires at 3am Sun.
+#
+# 3. Label selector `app.kubernetes.io/component=proxy` — matches only the
+#    data-plane pod, not the control-plane `envoy-gateway` controller.
+#    Control plane has its own much-slower drift pattern and is left alone.
+#
+# 4. RBAC scoped to `envoy-gateway-system` namespace, pods resource only.
+#    No cluster-wide permissions. Cannot affect any other workload.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy-data-plane-rotator
+  namespace: envoy-gateway-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: envoy-data-plane-rotator
+  namespace: envoy-gateway-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: envoy-data-plane-rotator
+  namespace: envoy-gateway-system
+subjects:
+  - kind: ServiceAccount
+    name: envoy-data-plane-rotator
+    namespace: envoy-gateway-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: envoy-data-plane-rotator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: envoy-data-plane-rotate
+  namespace: envoy-gateway-system
+spec:
+  # Sunday 10:00 UTC = Sunday 03:00 PDT (US off-peak for quixit's user base)
+  schedule: "0 10 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: envoy-data-plane-rotator
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: bitnami/kubectl:1.35
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  echo "Rotating Envoy data-plane pod(s) in envoy-gateway-system..."
+                  pods=$(kubectl get pods -n envoy-gateway-system \
+                    -l 'app.kubernetes.io/component=proxy' \
+                    -o name)
+                  if [ -z "$pods" ]; then
+                    echo "No data-plane pods found — nothing to rotate."
+                    exit 0
+                  fi
+                  echo "Found pod(s):"
+                  echo "$pods"
+                  echo "$pods" | xargs -r kubectl delete -n envoy-gateway-system --grace-period=30
+                  echo "Deletion issued. Deployment controller will recreate."
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi

--- a/infrastructure/kustomization.yml
+++ b/infrastructure/kustomization.yml
@@ -21,6 +21,7 @@ resources:
   - envoy-gateway/gatewayclass.yml
   - envoy-gateway/envoyproxy.yml
   - envoy-gateway/gateway.yml
+  - envoy-gateway/cronjob-rotate.yml
   # nfs-provisioner
   - nfs-provisioner/namespace.yml
   - nfs-provisioner/video-storage.yml


### PR DESCRIPTION
## What

Adds a weekly `CronJob` that deletes the Envoy data-plane pod every Sunday 03:00 PDT (10:00 UTC). The Deployment recreates immediately. Plus the required ServiceAccount + Role + RoleBinding scoped tightly to `envoy-gateway-system/pods`.

## Why

Belt-and-suspenders for the TCMalloc-under-cgroup-pressure failure mode that took down quixit.us + auth.quixit.us on 2026-05-14 after 33 days of Envoy uptime. rpi-k3s PR #41 raised memory limits (256Mi → 1Gi data-plane) and bumped Envoy Gateway v1.7.1 → v1.8.0 (deferred stat creation), pushing the natural failure interval out to many months. This CronJob makes uptime a controlled variable instead of waiting for the ceiling.

## Design choices (each load-bearing)

1. **`kubectl delete pod` not `rollout restart`** — Flux ignores pod-level ops. `rollout restart` adds the `kubectl.kubernetes.io/restartedAt` annotation, which Flux reverts on next reconcile, triggering wave-2 restarts across the cluster (the 2026-05-14 cascade). Pod deletion is invisible to Flux.

2. **Sunday 10:00 UTC = 03:00 PDT** — verified dead window for quixit's small US-centric user base. 5-min scheduler ticker absorbs the API blip; cycle phase transitions are admin-set times and don't land in this window.

3. **Label selector `app.kubernetes.io/component=proxy`** — rotates only the data-plane pod, leaves control plane alone (slower drift pattern, separately memory-bumped to 512Mi in PR #41).

4. **RBAC scoped to `envoy-gateway-system` namespace, pods resource only** — no cluster-wide permissions. Cannot affect any other workload.

## Files

- `infrastructure/envoy-gateway/cronjob-rotate.yml` — new, ~100 lines (ServiceAccount + Role + RoleBinding + CronJob)
- `infrastructure/kustomization.yml` — adds the new resource to the envoy-gateway block

## Validation after merge

```bash
flux reconcile source git flux-system
flux reconcile kustomization infrastructure
kubectl get cronjob -n envoy-gateway-system
# Should show envoy-data-plane-rotate with schedule "0 10 * * 0"
```

Manual smoke test (without waiting for Sunday):

```bash
kubectl create job -n envoy-gateway-system --from=cronjob/envoy-data-plane-rotate manual-rotate-test-$(date +%s)
kubectl logs -n envoy-gateway-system -l job-name=manual-rotate-test-*
# Expect: "Found pod(s): pod/envoy-eg-...; Deletion issued."
kubectl get pods -n envoy-gateway-system -w
# Expect: data-plane pod terminates and a fresh one comes up 2/2 Running within ~30s
```

## What this does NOT do (explicit non-goals)

- Doesn't fix root cause (TCMalloc + cgroup interaction is fundamental)
- Doesn't add HA — there's still a 5-10s blip during the rotation
- Doesn't add memory monitoring/alerts (separate concern, no Prometheus stack deployed)

Future considerations if the rotation downtime ever proves to hurt: `replicas: 2` on the data-plane (modest extra cost on kube-worker4). Documented but not shipped.