### PR TITLE
fix(envoy-gateway): use rancher/kubectl image in rotation CronJob

### DIFF
--- a/infrastructure/envoy-gateway/cronjob-rotate.yml
+++ b/infrastructure/envoy-gateway/cronjob-rotate.yml
@@ -79,7 +79,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: kubectl
-              image: bitnami/kubectl:1.35
+              image: rancher/kubectl:v1.35.1
               command:
                 - sh
                 - -c


### PR DESCRIPTION
Follow-up to PR #42. Initial CronJob shipped with `bitnami/kubectl:1.35` which doesn't exist on Docker Hub's free tier (Bitnami restructured image distribution in 2025). Smoke test confirmed ImagePullBackOff. Switching to `rancher/kubectl:v1.35.1` which matches the running k3s version and is the canonical kubectl image in K3s ecosystems.