### PR TITLE
feat(quixit): bump to 0.27.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.26.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.27.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- Bumps `apps/quixit/deployment.yml` image tag from `0.26.0` → `0.27.0`
- Picks up [quixit#135](https://github.com/ianhundere/quixit/pull/135) (chosen username in sample/song pack contributors)

## Test plan

- [ ] Merge → Flux reconciles within ~1 min
- [ ] `kubectl -n quixit get pods` shows new replica running
- [ ] Trigger a sample-pack regenerate on an active cycle; confirm README "Contributors:" and in-zip filenames show chosen usernames for users who set one
- [ ] **Before regenerating any pack:** run `SELECT COUNT(*) FROM users WHERE username IS NOT NULL AND username !~ '^[a-zA-Z0-9_]{3,32}$';` against prod. If non-zero, hold and revisit defense-in-depth note in quixit deferred-work.md.