### PR TITLE
fix(quixit): add Envoy timeout override for /api/chat/stream SSE

### DIFF
--- a/apps/quixit/gateway.yml
+++ b/apps/quixit/gateway.yml
@@ -61,6 +61,39 @@ spec:
     backendRefs:
     - name: quixit
       port: 8080
+  # Chat live-stream SSE: identical failure mode to /api/sse above. This route
+  # was missed when the IRC chat bridge shipped its own stream endpoint, so
+  # Envoy's default 15s route timeout killed /api/chat/stream before the 20s
+  # keepalive could fire — every connection died at ~15s, forcing a reconnect
+  # storm and dropping live cross-device message delivery (messages persisted
+  # to the DB but never fanned out live). timeouts: 0s mirrors /api/sse;
+  # BackendTrafficPolicy below still caps the connection at 600s.
+  # NOTE: every server-sent-events / long-poll route MUST be listed here.
+  # Current SSE/long-poll routes: /api/sse, /api/chat/stream.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api/chat/stream
+    timeouts:
+      request: "0s"
+      backendRequest: "0s"
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        add:
+        - name: Strict-Transport-Security
+          value: "max-age=31536000; includeSubDomains; preload"
+        - name: Access-Control-Allow-Origin
+          value: "*"
+        - name: Access-Control-Allow-Credentials
+          value: "true"
+        - name: Referrer-Policy
+          value: "strict-origin-when-cross-origin"
+        - name: X-Content-Type-Options
+          value: "nosniff"
+    backendRefs:
+    - name: quixit
+      port: 8080
   # Long-tail downloads: Envoy's 15s default route timeout cuts ZIP
   # downloads mid-stream for users on modest connections (~12Mbps user
   # reported a "failed network error" at 22MB into a sample-pack


### PR DESCRIPTION
## Problem

Chat messages were not appearing live across devices. Investigation traced it to the Envoy gateway: **`/api/chat/stream` (the IRC chat live-stream SSE endpoint) was missing the `timeouts.request: "0s"` override** that `/api/sse` already has.

Without the override, the route falls through to the catch-all `/` rule and inherits Envoy's **default 15s route timeout**. The backend keepalive ticker fires at **20s** (`chat.go:401`), so the connection was always killed *before* the first keepalive — every `/api/chat/stream` connection died at ~15000ms.

Live pod logs confirmed the pattern (every connection ~15s, then reconnect):
```
/api/chat/stream  status:200  duration_ms:14999
/api/chat/stream  status:200  duration_ms:15006
/api/chat/stream  status:200  duration_ms:14999   ... (every ~15s)
```

Messages were **never lost** — they persisted to the DB fine. The break was live fan-out: any message broadcast during another device's dead/reconnecting window (or while a tab was backgrounded) was missed, only reappearing on a full reload.

## Fix

Add a `/api/chat/stream` HTTPRoute rule mirroring the existing `/api/sse` rule exactly (`timeouts.request/backendRequest: "0s"` + the same response headers). The `BackendTrafficPolicy` still caps the connection at 600s; the client auto-reconnects on drop.

Also enumerated all SSE/long-poll routes in a comment (`/api/sse`, `/api/chat/stream`) so the next stream route isn't forgotten.

## Verification
- `yaml.safe_load_all` parses cleanly.
- Gateway API uses longest-prefix match, so `/api/chat/stream` wins over `/`.
- After Flux reconciles, `/api/chat/stream` connections should live to ~600s instead of dying at 15s.