### PR TITLE
chore(quixit): bump image to v0.28.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.27.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.28.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
UX sweep release — quixit#138 (mobile nav profile pin + phase-aware upload link), #139 (deep-link auth bounce fix), #140 (admin audit-log IRC nick filter), #141 (polish bundle), #143 (chat viewport pane + nav unread dot).

Release: https://github.com/ianhundere/quixit/releases/tag/v0.28.0