### PR TITLE
fix: bump quixit to v0.28.1

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.28.0 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.28.1 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Deploys quixit v0.28.1 — the deep-module refactor sweep (6 refactors: useSseStream transport, upload-intake seam, CycleService.PlanDeadlineEdit, activityService transport, useChatSession facade, radio playback state machine). Image built + confirmed on GHCR; ImagePolicy resolves to 0.28.1.