### PR TITLE
fix(quixit): allow Google Fonts + Workbox CDN in CSP

### DIFF
--- a/apps/quixit/gateway.yml
+++ b/apps/quixit/gateway.yml
@@ -184,7 +184,12 @@ spec:
         - name: Permissions-Policy
           value: "camera=(), microphone=(), geolocation=()"
         - name: Content-Security-Policy
-          value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+          # Google Fonts (googleapis stylesheet + gstatic font files) and the
+          # Workbox service-worker runtime (storage.googleapis.com CDN, loaded
+          # via importScripts in sw.js) are narrowly allowlisted — the app has
+          # always loaded these; the strict default-src 'self' just wasn't
+          # updated to match, so both were CSP-blocked in the console.
+          value: "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'"
     backendRefs:
     - name: quixit
       port: 8080


### PR DESCRIPTION
The strict CSP (`default-src 'self'`) blocked two resources the app has always loaded — surfaced as console errors during v0.28.1 prod validation:

- **Fonts:** `style-src` blocked the Google Fonts stylesheet (`fonts.googleapis.com`) → Press Start 2P / Space Mono fell back to system fonts.
- **Service worker:** `script-src` blocked `sw.js`'s `importScripts()` of the Workbox runtime (`storage.googleapis.com`) → SW registration failed (`script evaluation failed`).

Fix: narrowly allowlist those origins (+ a `font-src` for `fonts.gstatic.com`). Nothing else opened; `connect-src` stays `'self'`. Infra-only — deploys via Flux, no quixit image rebuild.

Alternative considered: self-hosting fonts + Workbox to keep CSP maximally strict. Deferred as larger (backend static-route + version coupling + can't verify SW locally); this aligns the CSP with the app's existing design.