### PR TITLE
fix(envoy-gateway): pin proxy to amd64 after RPi kernel 48-bit VA revert

### DIFF
--- a/infrastructure/envoy-gateway/envoyproxy.yml
+++ b/infrastructure/envoy-gateway/envoyproxy.yml
@@ -1,7 +1,16 @@
 ---
 # EnvoyProxy configures the data plane proxy pods.
-# Note: RPi4 nodes recompiled with CONFIG_ARM64_VA_BITS_48=y (kernel 6.12.77-v8+)
-# to support Envoy's TCMalloc. No architecture constraint needed.
+# Envoy's TCMalloc requires a 48-bit virtual address space; stock RPi OS
+# kernels ship CONFIG_ARM64_VA_BITS=39, so Envoy aborts at startup logging
+# "MmapAligned() failed ... TCMalloc assumes a 48-bit virtual address space"
+# (exit 133 — distinct from the memory-pressure abort described on the limits
+# below). Custom 48-bit RPi kernels fixed this in 2026-03 but were overwritten
+# by a linux-image-rpi-v8 package update, so the proxy is pinned to amd64.
+# Remove the pin only once rebuilt 48-bit kernels are back on the RPi nodes
+# AND held against package upgrades (apt-mark hold or a custom kernel=
+# filename in config.txt). Trade-off while pinned: the sole amd64 node is an
+# ingress SPOF, and with externalTrafficPolicy: Local MetalLB announces the
+# LB IP from that one node only.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -16,6 +25,9 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyDeployment:
+        pod:
+          nodeSelector:
+            kubernetes.io/arch: amd64
         container:
           resources:
             requests:


### PR DESCRIPTION
Root cause of the 2026-07-05 10h data-plane crashloop (121 restarts): the custom 48-bit-VA RPi kernels (2026-03, `6.12.77-v8+`) were silently replaced by the stock `linux-image-rpi-v8 6.12.87+rpt` package on all four RPi nodes. Stock RPi kernels are `CONFIG_ARM64_VA_BITS=39`; Envoy's TCMalloc requires 48-bit VA and aborts at startup (exit 133).

**Independently reproduced before merging:** ran `envoyproxy/envoy:distroless-v1.38.0` pinned to kube-worker1 → instant exit 133 with `MmapAligned() failed … TCMalloc assumes a 48-bit virtual address space`. Today's rotation CronJob deleted the pod and the scheduler landed the replacement on worker1 → 10h crashloop; the manual restart landing on worker4 (the sole amd64 node) was scheduler luck.

Pin `kubernetes.io/arch: amd64` so placement is deterministic. Known trade-off (documented in the header comment): worker4 becomes the ingress SPOF, and with `externalTrafficPolicy: Local` MetalLB announces from that node only. Un-pin criteria: rebuilt 48-bit kernels back on the RPi nodes AND held against apt upgrades.