### PR TITLE
feat(tools): 48-bit VA kernel build + safe install tooling for RPi nodes

### DIFF
--- a/tools/rpi-kernel-48bit/README.md
+++ b/tools/rpi-kernel-48bit/README.md
@@ -40,7 +40,9 @@ Stock DTBs/overlays are kept (same-series 6.12.y DTBs are compatible); the
 build ships only the kernel Image + its module tree.
 
 **No-initramfs contract:** with `kernel=kernel8-48bit.img`, `auto_initramfs=1`
-no longer name-matches an initramfs, so the custom kernel boots without one.
+no longer name-matches an initramfs, so the custom kernel boots without one
+(side effect: no early-boot fsck of the rootfs — run `sudo fsck -fn /dev/mmcblk0p2`
+manually if SD corruption is ever suspected).
 That is safe **only because** the SD-card rootfs path is built-in — the build
 script asserts `CONFIG_MMC_BCM2835=y`, `CONFIG_MMC_SDHCI_IPROC=y`,
 `CONFIG_EXT4_FS=y` and fails the build if a future defconfig demotes them.
@@ -75,7 +77,7 @@ kubectl logs envoy-va-check          # expect a version banner, NOT MmapAligned
 kubectl delete pod envoy-va-check
 # k3s health on the new kernel (CNI sandbox creation is exercised by the pod
 # above; also confirm the node's daemonsets recovered):
-kubectl get node <node>              # Ready
+kubectl get node <node>              # Ready,SchedulingDisabled (cordoned until promote)
 kubectl get pods -A -o wide --field-selector spec.nodeName=<node>   # daemonsets Running
 ```
 

--- a/tools/rpi-kernel-48bit/README.md
+++ b/tools/rpi-kernel-48bit/README.md
@@ -1,0 +1,87 @@
+# 48-bit VA kernels for the Raspberry Pi nodes
+
+## Why
+
+Envoy's statically-linked Google TCMalloc **requires a 48-bit virtual address
+space**. Stock Raspberry Pi OS kernels ship `CONFIG_ARM64_VA_BITS=39`, so every
+official arm64 Envoy binary aborts instantly on an RPi node:
+
+```
+MmapAligned() failed … TCMalloc assumes a 48-bit virtual address space
+```
+
+Upstream will not fix this (envoy#23339 — maintainer verdict: *"recompile Envoy
+or use a kernel which supports it"*; google/tcmalloc#82 open, `kAddressBits=48`
+hardcoded for aarch64). Custom 48-bit kernels were first built in 2026-03 but
+were installed **over `kernel8.img`**, so the stock `linux-image-rpi-v8`
+6.12.87 package update silently destroyed them — causing the 2026-07-05
+Envoy data-plane crashloop (121 restarts / 10h) and the interim amd64 pin
+(rpi-k3s#49).
+
+## The clobber-proof mechanism
+
+1. The custom kernel is installed as **`/boot/firmware/kernel8-48bit.img`** —
+   a filename no apt package owns or writes.
+2. `kernel=kernel8-48bit.img` in `config.txt` makes the firmware boot it.
+   apt kernel updates keep writing `kernel8.img`, which is unused but stays
+   fresh as an instant rollback target.
+3. A post-apt hook (`/etc/apt/apt.conf.d/99-48bit-kernel-guard`) warns on every
+   apt run if the pin or the kernel file ever goes missing.
+4. `apt-mark hold linux-image-rpi-v8` is **deliberately not used**: with the
+   custom filename the stock package can't hurt us, and letting it update keeps
+   the fallback kernel patched. (Hold it anyway if you prefer belt-and-braces —
+   it's harmless, just noisy on upgrades.)
+
+Stock DTBs/overlays are kept (same-series 6.12.y DTBs are compatible); the
+build ships only the kernel Image + its module tree.
+
+## Usage
+
+```bash
+# 1. Build (x86_64 workstation, aarch64-linux-gnu- toolchain, ~15-25 min)
+./build-48bit-kernel.sh                     # → out/rpi-kernel-48bit-<ver>-<sha>.tar.gz
+
+# 2. Per node, canary-style (worker first, kube-master LAST):
+./install-48bit-kernel.sh kube-worker1 out/<tarball> stage     # copy files, no reboot
+./install-48bit-kernel.sh kube-worker1 out/<tarball> tryboot   # drain + ONE-SHOT boot
+# … validate (below) …
+./install-48bit-kernel.sh kube-worker1 out/<tarball> promote   # permanent + guard + uncordon
+
+# Rollback at any point:
+./install-48bit-kernel.sh <node> out/<tarball> rollback
+```
+
+### Validation battery (per node, after tryboot and again after promote)
+
+```bash
+ssh <node> uname -r                          # expect …-v8-48bit
+# The decisive test — official Envoy must start where it used to abort:
+kubectl run envoy-va-check --image=docker.io/envoyproxy/envoy:distroless-v1.38.3 \
+  --restart=Never --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"<node>"}}}' \
+  -- --version
+kubectl logs envoy-va-check   # expect a version banner, NOT the MmapAligned abort
+kubectl delete pod envoy-va-check
+kubectl get node <node>       # Ready
+```
+
+### Risk notes
+
+- `tryboot` is one-shot: a panicking kernel reboots back onto stock. A **hung**
+  kernel needs a physical power cycle (the node is drained, so the cluster is
+  fine meanwhile). Canary on a worker; do kube-master last.
+- Node reboots move single-replica workloads (quixit app, postgres are on
+  worker4/amd64 and are not touched by RPi reboots).
+
+## Un-pin criteria (rpi-k3s#49)
+
+Once **all four** RPi nodes run the 48-bit kernel with the guard installed,
+remove the `kubernetes.io/arch: amd64` nodeSelector from
+`infrastructure/envoy-gateway/envoyproxy.yml` (revert of #49) so the Envoy
+data plane can schedule anywhere again — eliminating the worker4 ingress SPOF.
+
+## Refresh procedure
+
+Rebuild when the RPi kernel series moves (e.g. 6.12 → 6.15) or ~quarterly:
+re-run `build-48bit-kernel.sh` (it tracks `rpi-6.12.y` — bump `KERNEL_BRANCH`
+when the series changes), then `stage` + `tryboot` + `promote` per node. The
+old module tree can be removed after the new one is promoted.

--- a/tools/rpi-kernel-48bit/README.md
+++ b/tools/rpi-kernel-48bit/README.md
@@ -14,26 +14,36 @@ Upstream will not fix this (envoy#23339 — maintainer verdict: *"recompile Envo
 or use a kernel which supports it"*; google/tcmalloc#82 open, `kAddressBits=48`
 hardcoded for aarch64). Custom 48-bit kernels were first built in 2026-03 but
 were installed **over `kernel8.img`**, so the stock `linux-image-rpi-v8`
-6.12.87 package update silently destroyed them — causing the 2026-07-05
-Envoy data-plane crashloop (121 restarts / 10h) and the interim amd64 pin
-(rpi-k3s#49).
+6.12.87 package update silently destroyed them — causing the 2026-07-05 Envoy
+data-plane crashloop (121 restarts / 10h) and the interim amd64 pin (rpi-k3s#49).
 
 ## The clobber-proof mechanism
 
-1. The custom kernel is installed as **`/boot/firmware/kernel8-48bit.img`** —
-   a filename no apt package owns or writes.
-2. `kernel=kernel8-48bit.img` in `config.txt` makes the firmware boot it.
-   apt kernel updates keep writing `kernel8.img`, which is unused but stays
-   fresh as an instant rollback target.
-3. A post-apt hook (`/etc/apt/apt.conf.d/99-48bit-kernel-guard`) warns on every
-   apt run if the pin or the kernel file ever goes missing.
-4. `apt-mark hold linux-image-rpi-v8` is **deliberately not used**: with the
+1. The custom kernel lives at **`/boot/firmware/kernel8-48bit.img`** — a
+   filename no apt package owns or writes. `kernel=kernel8-48bit.img` in
+   `config.txt` boots it. apt keeps updating the unused stock `kernel8.img`,
+   which stays fresh as the rollback target.
+2. **Trial-file staging:** `stage` writes `kernel8-48bit-trial.img` and never
+   touches the pinned kernel — so a **refresh** of an already-promoted node has
+   the same safety as the first install: the running kernel is only replaced by
+   `promote`, *after* the trial has successfully booted.
+3. A post-apt hook (`99-48bit-kernel-guard`) checks the pin after every dpkg
+   operation and, if broken, prints a WARNING **and** logs to journald
+   (`logger -p user.err -t 48bit-kernel-guard`). `promote` validates the guard
+   with `apt-get check` before declaring success. Note the hook fires on
+   package operations (install/upgrade/remove), not on bare `apt update`.
+4. `apt-mark hold linux-image-rpi-v8` is deliberately **not** used: with the
    custom filename the stock package can't hurt us, and letting it update keeps
-   the fallback kernel patched. (Hold it anyway if you prefer belt-and-braces —
-   it's harmless, just noisy on upgrades.)
+   the fallback kernel patched. (Hold anyway if you want belt-and-braces.)
 
 Stock DTBs/overlays are kept (same-series 6.12.y DTBs are compatible); the
 build ships only the kernel Image + its module tree.
+
+**No-initramfs contract:** with `kernel=kernel8-48bit.img`, `auto_initramfs=1`
+no longer name-matches an initramfs, so the custom kernel boots without one.
+That is safe **only because** the SD-card rootfs path is built-in — the build
+script asserts `CONFIG_MMC_BCM2835=y`, `CONFIG_MMC_SDHCI_IPROC=y`,
+`CONFIG_EXT4_FS=y` and fails the build if a future defconfig demotes them.
 
 ## Usage
 
@@ -41,47 +51,69 @@ build ships only the kernel Image + its module tree.
 # 1. Build (x86_64 workstation, aarch64-linux-gnu- toolchain, ~15-25 min)
 ./build-48bit-kernel.sh                     # → out/rpi-kernel-48bit-<ver>-<sha>.tar.gz
 
-# 2. Per node, canary-style (worker first, kube-master LAST):
-./install-48bit-kernel.sh kube-worker1 out/<tarball> stage     # copy files, no reboot
+# 2. Per node — canary a worker first, kube-master LAST (control-plane API is
+#    down during its reboot; find problems on workers first):
+./install-48bit-kernel.sh kube-worker1 out/<tarball> stage     # trial file, no reboot
 ./install-48bit-kernel.sh kube-worker1 out/<tarball> tryboot   # drain + ONE-SHOT boot
 # … validate (below) …
-./install-48bit-kernel.sh kube-worker1 out/<tarball> promote   # permanent + guard + uncordon
+./install-48bit-kernel.sh kube-worker1 out/<tarball> promote   # pin + guard + reboot + verify + uncordon
 
-# Rollback at any point:
+# Rollback at any point (drains, removes pin+guard, reboots to stock, verifies):
 ./install-48bit-kernel.sh <node> out/<tarball> rollback
 ```
 
-### Validation battery (per node, after tryboot and again after promote)
+### Validation battery (after tryboot, and again after promote)
 
 ```bash
-ssh <node> uname -r                          # expect …-v8-48bit
-# The decisive test — official Envoy must start where it used to abort:
+ssh <node> uname -r     # expect …-v8-48bit+
+# Decisive test — official Envoy must start where it used to abort with exit 133.
+# nodeName (not nodeSelector) bypasses the scheduler, so this runs on the
+# still-CORDONED node during the tryboot window:
 kubectl run envoy-va-check --image=docker.io/envoyproxy/envoy:distroless-v1.38.3 \
-  --restart=Never --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"<node>"}}}' \
-  -- --version
-kubectl logs envoy-va-check   # expect a version banner, NOT the MmapAligned abort
+  --restart=Never --overrides='{"spec":{"nodeName":"<node>"}}' -- --version
+kubectl logs envoy-va-check          # expect a version banner, NOT MmapAligned
 kubectl delete pod envoy-va-check
-kubectl get node <node>       # Ready
+# k3s health on the new kernel (CNI sandbox creation is exercised by the pod
+# above; also confirm the node's daemonsets recovered):
+kubectl get node <node>              # Ready
+kubectl get pods -A -o wide --field-selector spec.nodeName=<node>   # daemonsets Running
 ```
 
-### Risk notes
+### Fleet check (the un-pin gate)
 
-- `tryboot` is one-shot: a panicking kernel reboots back onto stock. A **hung**
-  kernel needs a physical power cycle (the node is drained, so the cluster is
-  fine meanwhile). Canary on a worker; do kube-master last.
-- Node reboots move single-replica workloads (quixit app, postgres are on
-  worker4/amd64 and are not touched by RPi reboots).
+All four RPi nodes must pass before removing the Envoy amd64 pin:
+
+```bash
+for n in kube-worker1 kube-worker2 kube-worker3 kube-master; do
+  echo "== $n: $(ssh $n 'uname -r; grep -c ^kernel=kernel8-48bit.img /boot/firmware/config.txt; test -f /etc/apt/apt.conf.d/99-48bit-kernel-guard && echo guard-ok' | paste -sd" ")"
+done   # each line: <release ending -v8-48bit+> 1 guard-ok
+```
+
+### Risk notes — read before the first tryboot
+
+- `tryboot` is one-shot and `tryboot` ensures `panic=10` in `cmdline.txt`, so a
+  **panicking** trial kernel self-reboots back onto the stock config within
+  ~10s. A **hung** trial kernel does NOT self-recover — it needs a physical
+  power cycle (the node is drained first, so the cluster is fine meanwhile).
+  After any power event which kernel boots is decided by `config.txt`: stock
+  unless `promote` has pinned.
+- If `drain` fails (PDB / stuck pod) the script stops with the node cordoned
+  and tells you; nothing has been rebooted at that point.
+- Node reboots move single-replica workloads. quixit app + postgres live on
+  worker4 (amd64) and are untouched by RPi reboots.
 
 ## Un-pin criteria (rpi-k3s#49)
 
-Once **all four** RPi nodes run the 48-bit kernel with the guard installed,
-remove the `kubernetes.io/arch: amd64` nodeSelector from
-`infrastructure/envoy-gateway/envoyproxy.yml` (revert of #49) so the Envoy
-data plane can schedule anywhere again — eliminating the worker4 ingress SPOF.
+Once the **fleet check** above passes on all four RPi nodes, remove the
+`kubernetes.io/arch: amd64` nodeSelector from
+`infrastructure/envoy-gateway/envoyproxy.yml` (revert of #49) so the Envoy data
+plane can schedule anywhere again — eliminating the worker4 ingress SPOF.
 
 ## Refresh procedure
 
-Rebuild when the RPi kernel series moves (e.g. 6.12 → 6.15) or ~quarterly:
-re-run `build-48bit-kernel.sh` (it tracks `rpi-6.12.y` — bump `KERNEL_BRANCH`
-when the series changes), then `stage` + `tryboot` + `promote` per node. The
-old module tree can be removed after the new one is promoted.
+Rebuild when the RPi kernel series moves (e.g. 6.12 → 6.15) or ~quarterly.
+Because `stage` writes only the trial file, a refresh is **identical to a first
+install**: `build` → `stage` → `tryboot` → validate → `promote`, per node. The
+build script re-asserts the no-initramfs contract each time. Old module trees
+under `/lib/modules/` can be pruned after the new release is promoted
+everywhere.

--- a/tools/rpi-kernel-48bit/build-48bit-kernel.sh
+++ b/tools/rpi-kernel-48bit/build-48bit-kernel.sh
@@ -51,6 +51,14 @@ make olddefconfig
 grep -q '^CONFIG_ARM64_VA_BITS_48=y' .config || { echo "FATAL: VA_BITS_48 not set after olddefconfig"; exit 1; }
 grep -q '^CONFIG_ARM64_VA_BITS=48'   .config || { echo "FATAL: ARM64_VA_BITS != 48"; exit 1; }
 
+# No-initramfs boot contract: the custom kernel filename breaks auto_initramfs
+# name-matching, so the node boots WITHOUT an initramfs. That is only safe while
+# the SD-card rootfs path is built-in. Fail the build if a future defconfig
+# demotes any of these to =m (see README "No-initramfs contract").
+for opt in CONFIG_MMC_BCM2835 CONFIG_MMC_SDHCI_IPROC CONFIG_EXT4_FS CONFIG_BLK_DEV_SD; do
+  grep -q "^${opt}=y" .config || { echo "FATAL: ${opt} is not built-in — no-initramfs boot would fail"; exit 1; }
+done
+
 echo "==> Build (-j${JOBS}) — Image + modules"
 make -j"${JOBS}" Image modules
 

--- a/tools/rpi-kernel-48bit/build-48bit-kernel.sh
+++ b/tools/rpi-kernel-48bit/build-48bit-kernel.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Cross-compile a Raspberry Pi OS kernel (Pi 4 / bcm2711) with 48-bit virtual
+# addressing, for running Envoy (Google TCMalloc requires CONFIG_ARM64_VA_BITS=48;
+# stock RPi OS kernels ship VA_BITS=39 and Envoy aborts at startup with exit 133).
+#
+# Runs on an x86_64 workstation with the aarch64-linux-gnu- toolchain.
+# Produces: out/rpi-kernel-48bit-<kernelrelease>-<sha>.tar.gz containing
+#   boot/kernel8-48bit.img          (the kernel Image, custom filename apt never touches)
+#   modules/lib/modules/<release>/  (stripped module tree)
+#   KERNEL_RELEASE                  (one line: the exact release string)
+#
+# Design notes (see README.md):
+# - Custom kernel FILENAME + a `kernel=` line in config.txt is the clobber-proof
+#   mechanism: apt kernel updates write kernel8.img and cannot overwrite a file
+#   they do not own. (The 2026-03 build installed OVER kernel8.img and was
+#   silently destroyed by the linux-image-rpi-v8 6.12.87 update.)
+# - Stock DTBs/overlays are kept: same-series (6.12.y) DTBs are compatible and
+#   letting apt keep refreshing them avoids a second ownership fight.
+set -euo pipefail
+
+BRANCH="${KERNEL_BRANCH:-rpi-6.12.y}"
+SRC_DIR="${KERNEL_SRC:-/tmp/rpi-linux-48bit}"
+OUT_DIR="$(cd "$(dirname "$0")" && pwd)/out"
+JOBS="${JOBS:-$(nproc)}"
+CROSS=aarch64-linux-gnu-
+
+command -v "${CROSS}gcc" >/dev/null || { echo "FATAL: ${CROSS}gcc not found"; exit 1; }
+
+echo "==> Source: raspberrypi/linux @ ${BRANCH} (dir: ${SRC_DIR})"
+if [ ! -d "${SRC_DIR}/.git" ]; then
+  git clone --depth=1 --branch "${BRANCH}" https://github.com/raspberrypi/linux.git "${SRC_DIR}"
+else
+  git -C "${SRC_DIR}" fetch --depth=1 origin "${BRANCH}"
+  git -C "${SRC_DIR}" checkout -q FETCH_HEAD
+fi
+SHA=$(git -C "${SRC_DIR}" rev-parse --short HEAD)
+echo "==> Pinned commit: ${SHA}"
+
+cd "${SRC_DIR}"
+export ARCH=arm64 CROSS_COMPILE="${CROSS}"
+
+echo "==> Configure: bcm2711_defconfig + VA_BITS_48 + LOCALVERSION -v8-48bit"
+make bcm2711_defconfig
+./scripts/config --disable CONFIG_ARM64_VA_BITS_39
+./scripts/config --enable  CONFIG_ARM64_VA_BITS_48
+./scripts/config --set-str CONFIG_LOCALVERSION "-v8-48bit"
+./scripts/config --disable CONFIG_LOCALVERSION_AUTO
+make olddefconfig
+
+# The whole point — fail loudly if the choice didn't take.
+grep -q '^CONFIG_ARM64_VA_BITS_48=y' .config || { echo "FATAL: VA_BITS_48 not set after olddefconfig"; exit 1; }
+grep -q '^CONFIG_ARM64_VA_BITS=48'   .config || { echo "FATAL: ARM64_VA_BITS != 48"; exit 1; }
+
+echo "==> Build (-j${JOBS}) — Image + modules"
+make -j"${JOBS}" Image modules
+
+KREL=$(make -s kernelrelease)
+echo "==> kernelrelease: ${KREL}"
+case "${KREL}" in *-v8-48bit*) ;; *) echo "FATAL: unexpected kernelrelease ${KREL}"; exit 1;; esac
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "${STAGE}"' EXIT
+mkdir -p "${STAGE}/boot" "${STAGE}/modules"
+cp arch/arm64/boot/Image "${STAGE}/boot/kernel8-48bit.img"
+make INSTALL_MOD_PATH="${STAGE}/modules" INSTALL_MOD_STRIP=1 modules_install >/dev/null
+printf '%s\n' "${KREL}" > "${STAGE}/KERNEL_RELEASE"
+
+mkdir -p "${OUT_DIR}"
+TARBALL="${OUT_DIR}/rpi-kernel-48bit-${KREL}-${SHA}.tar.gz"
+tar -C "${STAGE}" -czf "${TARBALL}" boot modules KERNEL_RELEASE
+echo "==> Artifact: ${TARBALL}"
+du -h "${TARBALL}"

--- a/tools/rpi-kernel-48bit/install-48bit-kernel.sh
+++ b/tools/rpi-kernel-48bit/install-48bit-kernel.sh
@@ -3,21 +3,24 @@
 # Run from the workstation (needs: ssh to node, kubectl for drain/uncordon).
 #
 # Usage:
-#   install-48bit-kernel.sh <node> <tarball> stage      # copy kernel + modules onto node (no reboot)
-#   install-48bit-kernel.sh <node> <tarball> tryboot    # drain + ONE-SHOT boot the new kernel (falls back to stock on next reset)
-#   install-48bit-kernel.sh <node> <tarball> promote    # make kernel= permanent in config.txt + install apt guard + reboot + uncordon
-#   install-48bit-kernel.sh <node> <tarball> rollback   # remove kernel= line, reboot back onto stock kernel
+#   install-48bit-kernel.sh <node> <tarball> stage      # copy kernel (as TRIAL file) + modules onto node; no reboot
+#   install-48bit-kernel.sh <node> <tarball> tryboot    # drain + ONE-SHOT boot the trial kernel
+#   install-48bit-kernel.sh <node> <tarball> promote    # trial -> pinned kernel8-48bit.img, config.txt pin, apt guard, reboot, verify, uncordon
+#   install-48bit-kernel.sh <node> <tarball> rollback   # remove pin + guard, reboot back onto stock kernel, verify
 #
 # Safety model:
-# - tryboot.txt is honoured by the Pi firmware for exactly one boot attempt
-#   (`reboot '0 tryboot'`); any subsequent reset boots stock config.txt. So a
-#   broken kernel strands the node only until a power cycle, never permanently.
-# - CAUTION: if the trial kernel HANGS (rather than panics+reboots), the node
-#   needs a physical power cycle — drain first, canary on a worker, never start
-#   with kube-master.
-# - promote appends `kernel=kernel8-48bit.img` to config.txt. apt kernel
-#   updates keep writing kernel8.img (unused, harmless, and a always-fresh
-#   rollback target); they cannot touch our file.
+# - stage NEVER touches a kernel the node currently boots: it writes
+#   kernel8-48bit-trial.img (+ a .krel marker). This makes refreshes safe too —
+#   the live pinned kernel8-48bit.img is only replaced by promote, after the
+#   trial booted successfully.
+# - tryboot.txt is honoured by the Pi firmware for exactly ONE boot attempt;
+#   any subsequent reset boots config.txt. tryboot also ensures `panic=10` in
+#   cmdline.txt so a PANICKING trial kernel self-reboots back onto the stock
+#   config. A HUNG kernel still needs a physical power cycle (node is drained
+#   first; canary on a worker; kube-master last).
+# - Every mutation runs in its own fully-error-checked ssh call; ONLY the bare
+#   reboot is allowed to drop the connection. Post-reboot verification checks
+#   the actual on-disk boot state, not just uname.
 set -euo pipefail
 
 NODE="${1:?usage: $0 <node> <tarball> stage|tryboot|promote|rollback}"
@@ -26,87 +29,150 @@ ACTION="${3:?missing action: stage|tryboot|promote|rollback}"
 
 SSH=(ssh -o BatchMode=yes -o ConnectTimeout=5 "${NODE}")
 FW=/boot/firmware
+TRIAL_IMG="kernel8-48bit-trial.img"
+FINAL_IMG="kernel8-48bit.img"
+GUARD=/etc/apt/apt.conf.d/99-48bit-kernel-guard
 
-wait_for_ssh() {
+krel() { tar -xzOf "${TARBALL}" KERNEL_RELEASE; }
+
+wait_for_down() {
+  echo "==> waiting for ${NODE} to go DOWN (max 90s)"
+  for _ in $(seq 1 18); do
+    if ! ssh -o BatchMode=yes -o ConnectTimeout=3 "${NODE}" true 2>/dev/null; then return 0; fi
+    sleep 5
+  done
+  echo "FATAL: ${NODE} never went down — the reboot did not happen; investigate before retrying"; return 1
+}
+
+wait_for_up() {
   local tries=60
   echo "==> waiting for ${NODE} to come back (max $((tries*5))s)"
   for _ in $(seq 1 "${tries}"); do
     if ssh -o BatchMode=yes -o ConnectTimeout=3 "${NODE}" true 2>/dev/null; then return 0; fi
     sleep 5
   done
-  echo "FATAL: ${NODE} did not return; if the trial kernel hung, power-cycle it (stock kernel boots next)"; return 1
+  echo "FATAL: ${NODE} did not return within $((tries*5))s."
+  echo "  If the kernel HUNG: power-cycle the node. Which kernel boots next is"
+  echo "  determined by ${FW}/config.txt (tryboot is one-shot; stock unless a"
+  echo "  kernel= pin was promoted). Node remains cordoned in k3s."
+  return 1
 }
 
-krel() { tar -xzOf "${TARBALL}" KERNEL_RELEASE; }
+reboot_node() {
+  # The ONLY place a dropped ssh connection is acceptable.
+  "${SSH[@]}" "sudo reboot ${1:-}" || true
+  wait_for_down
+  wait_for_up
+}
+
+drain_node() {
+  if ! kubectl drain "${NODE}" --ignore-daemonsets --delete-emptydir-data --timeout=120s; then
+    echo "FATAL: drain failed (PDB / stuck pod?). Node is now CORDONED but not drained."
+    echo "  Fix the eviction blocker and re-run, or 'kubectl uncordon ${NODE}' to abort."
+    return 1
+  fi
+}
 
 case "${ACTION}" in
 stage)
   KREL=$(krel)
-  echo "==> staging ${KREL} onto ${NODE}"
+  echo "==> staging ${KREL} onto ${NODE} (trial file — live kernel untouched)"
   scp -q "${TARBALL}" "${NODE}:/tmp/k48.tar.gz"
   "${SSH[@]}" "
     set -euo pipefail
-    sudo tar -C / --no-same-owner -xzf /tmp/k48.tar.gz modules
-    sudo mv /modules/lib/modules/${KREL} /lib/modules/ 2>/dev/null || sudo rsync -a /modules/lib/modules/${KREL}/ /lib/modules/${KREL}/
-    sudo rm -rf /modules
-    tar -xzOf /tmp/k48.tar.gz boot/kernel8-48bit.img | sudo tee ${FW}/kernel8-48bit.img >/dev/null
-    rm /tmp/k48.tar.gz
-    echo staged: \$(ls -la ${FW}/kernel8-48bit.img); ls -d /lib/modules/${KREL}
+    sudo rm -rf /tmp/k48-modules && mkdir -p /tmp/k48-modules
+    tar -C /tmp/k48-modules -xzf /tmp/k48.tar.gz modules KERNEL_RELEASE
+    sudo rsync -a --delete /tmp/k48-modules/modules/lib/modules/${KREL}/ /lib/modules/${KREL}/
+    # Atomic-ish kernel write: temp file on the same FAT fs, then rename.
+    tar -xzOf /tmp/k48.tar.gz boot/${FINAL_IMG} | sudo tee ${FW}/${TRIAL_IMG}.tmp >/dev/null
+    sudo mv ${FW}/${TRIAL_IMG}.tmp ${FW}/${TRIAL_IMG}
+    printf '%s\n' '${KREL}' | sudo tee ${FW}/kernel8-48bit-trial.krel >/dev/null
+    rm -rf /tmp/k48.tar.gz /tmp/k48-modules
+    echo \"staged: \$(ls -la ${FW}/${TRIAL_IMG})\"
+    ls -d /lib/modules/${KREL}
   "
   ;;
 
 tryboot)
   KREL=$(krel)
-  echo "==> drain ${NODE}"
-  kubectl drain "${NODE}" --ignore-daemonsets --delete-emptydir-data --timeout=120s
-  echo "==> one-shot tryboot of ${KREL} on ${NODE}"
+  echo "==> pre-flight: trial marker must match this tarball"
+  MARKER=$("${SSH[@]}" "cat ${FW}/kernel8-48bit-trial.krel 2>/dev/null" || true)
+  [ "${MARKER}" = "${KREL}" ] || { echo "FATAL: staged trial is '${MARKER}', tarball is '${KREL}' — re-run stage"; exit 1; }
+  echo "==> writing tryboot.txt (one-shot) + ensuring panic=10 in cmdline.txt"
   "${SSH[@]}" "
     set -euo pipefail
-    test -f ${FW}/kernel8-48bit.img
-    sudo cp ${FW}/config.txt ${FW}/tryboot.txt
-    echo 'kernel=kernel8-48bit.img' | sudo tee -a ${FW}/tryboot.txt >/dev/null
-    sudo reboot '0 tryboot'
-  " || true   # ssh drops on reboot
-  wait_for_ssh
+    test -f ${FW}/${TRIAL_IMG}
+    sudo sh -c 'sed \"/^kernel=/d\" ${FW}/config.txt > ${FW}/tryboot.txt'
+    echo 'kernel=${TRIAL_IMG}' | sudo tee -a ${FW}/tryboot.txt >/dev/null
+    grep -q 'panic=' ${FW}/cmdline.txt || sudo sed -i '1 s/\$/ panic=10/' ${FW}/cmdline.txt
+  "
+  echo "==> drain + one-shot tryboot of ${KREL} on ${NODE}"
+  drain_node
+  reboot_node "'0 tryboot'"
   GOT=$("${SSH[@]}" uname -r)
   if [ "${GOT}" = "${KREL}" ]; then
-    echo "==> TRYBOOT OK: ${NODE} is running ${GOT} (one-shot; a plain reboot returns to stock)"
+    echo "==> TRYBOOT OK: ${NODE} is running ${GOT} (one-shot; any reset returns to the config.txt kernel)"
+    echo "==> validate now (envoy repro uses nodeName so it runs on the cordoned node — see README), then promote"
   else
-    echo "FATAL: ${NODE} booted ${GOT}, expected ${KREL} — tryboot failed, node is on stock kernel"; exit 1
+    echo "FATAL: ${NODE} booted ${GOT}, expected ${KREL} — trial rejected; node is on its config.txt kernel and remains cordoned"
+    "${SSH[@]}" "sudo rm -f ${FW}/tryboot.txt"
+    exit 1
   fi
   ;;
 
 promote)
   KREL=$(krel)
   GOT=$("${SSH[@]}" uname -r)
-  [ "${GOT}" = "${KREL}" ] || { echo "FATAL: refusing to promote — ${NODE} is running ${GOT}, not ${KREL} (run tryboot first)"; exit 1; }
-  echo "==> promoting kernel= on ${NODE} + installing apt guard"
+  [ "${GOT}" = "${KREL}" ] || { echo "FATAL: refusing to promote — ${NODE} runs ${GOT}, not ${KREL} (run tryboot first)"; exit 1; }
+  MARKER=$("${SSH[@]}" "cat ${FW}/kernel8-48bit-trial.krel 2>/dev/null" || true)
+  [ "${MARKER}" = "${KREL}" ] || { echo "FATAL: trial marker '${MARKER}' != '${KREL}' — trial was re-staged since tryboot"; exit 1; }
+
+  echo "==> promoting: trial -> ${FINAL_IMG}, pin in config.txt (mutations, fully checked)"
   "${SSH[@]}" "
     set -euo pipefail
-    grep -q '^kernel=kernel8-48bit.img' ${FW}/config.txt || echo 'kernel=kernel8-48bit.img' | sudo tee -a ${FW}/config.txt >/dev/null
+    sudo mv ${FW}/${TRIAL_IMG} ${FW}/${FINAL_IMG}
+    sudo mv ${FW}/kernel8-48bit-trial.krel ${FW}/kernel8-48bit.krel
+    sudo sed -i '/^kernel=/d' ${FW}/config.txt
+    echo 'kernel=${FINAL_IMG}' | sudo tee -a ${FW}/config.txt >/dev/null
+    grep -q '^kernel=${FINAL_IMG}' ${FW}/config.txt
     sudo rm -f ${FW}/tryboot.txt
-    # Post-apt guard: warn loudly if the boot pin or the kernel file ever disappears.
-    printf 'DPkg::Post-Invoke { \"test -f ${FW}/kernel8-48bit.img && grep -q ^kernel=kernel8-48bit.img ${FW}/config.txt || echo \\\\\"WARNING: 48-bit kernel boot pin is BROKEN — Envoy will crash on this node after next reboot (see rpi-k3s tools/rpi-kernel-48bit)\\\\\" >&2\"; };\n' | sudo tee /etc/apt/apt.conf.d/99-48bit-kernel-guard >/dev/null
-    sudo reboot
-  " || true
-  wait_for_ssh
-  GOT=$("${SSH[@]}" uname -r)
-  [ "${GOT}" = "${KREL}" ] || { echo "FATAL: after promote, ${NODE} runs ${GOT}"; exit 1; }
+  "
+  echo "==> installing apt guard (single quoting layer via stdin) + validating apt still parses"
+  printf '%s\n' "DPkg::Post-Invoke { \"test -f ${FW}/${FINAL_IMG} && grep -q ^kernel=${FINAL_IMG} ${FW}/config.txt || { echo 'WARNING: 48-bit kernel boot pin is BROKEN - Envoy will crash on this node after next reboot (see rpi-k3s tools/rpi-kernel-48bit)' >&2; logger -p user.err -t 48bit-kernel-guard 'boot pin broken'; }\"; };" \
+    | "${SSH[@]}" "sudo tee ${GUARD} >/dev/null"
+  "${SSH[@]}" "sudo apt-get check -qq" || { echo "FATAL: apt rejects the guard file — removing it"; "${SSH[@]}" "sudo rm -f ${GUARD}"; exit 1; }
+
+  echo "==> reboot onto the pinned kernel"
+  reboot_node
+  echo "==> post-reboot verification (on-disk state, not just uname)"
+  "${SSH[@]}" "
+    set -euo pipefail
+    [ \"\$(uname -r)\" = '${KREL}' ]
+    grep -q '^kernel=${FINAL_IMG}' ${FW}/config.txt
+    test -f ${GUARD} && sudo apt-get check -qq
+  " || { echo "FATAL: post-promote verification failed on ${NODE} — node left cordoned"; exit 1; }
   kubectl uncordon "${NODE}"
-  echo "==> PROMOTED: ${NODE} permanently on ${KREL}; guard installed; node uncordoned"
+  echo "==> PROMOTED: ${NODE} permanently on ${KREL}; guard installed and apt-validated; node uncordoned"
   ;;
 
 rollback)
-  echo "==> rolling ${NODE} back to stock kernel"
+  echo "==> rolling ${NODE} back to stock kernel (drain first)"
+  kubectl cordon "${NODE}" >/dev/null 2>&1 || true
+  kubectl drain "${NODE}" --ignore-daemonsets --delete-emptydir-data --timeout=120s \
+    || echo "WARN: drain incomplete — continuing rollback anyway (emergency path)"
   "${SSH[@]}" "
     set -euo pipefail
-    sudo sed -i '/^kernel=kernel8-48bit.img/d' ${FW}/config.txt
-    sudo rm -f ${FW}/tryboot.txt /etc/apt/apt.conf.d/99-48bit-kernel-guard
-    sudo reboot
-  " || true
-  wait_for_ssh
-  echo "==> ${NODE} back on: $("${SSH[@]}" uname -r)"
-  kubectl uncordon "${NODE}" 2>/dev/null || true
+    sudo sed -i '/^kernel=/d' ${FW}/config.txt
+    sudo rm -f ${FW}/tryboot.txt ${GUARD}
+    ! grep -q '^kernel=' ${FW}/config.txt
+  "
+  reboot_node
+  GOT=$("${SSH[@]}" uname -r)
+  case "${GOT}" in
+    *-48bit*) echo "FATAL: ${NODE} still runs ${GOT} after rollback — investigate; node left cordoned"; exit 1 ;;
+    *)        echo "==> ROLLBACK OK: ${NODE} on stock ${GOT}" ;;
+  esac
+  kubectl uncordon "${NODE}"
   ;;
 
 *) echo "unknown action ${ACTION}"; exit 2 ;;

--- a/tools/rpi-kernel-48bit/install-48bit-kernel.sh
+++ b/tools/rpi-kernel-48bit/install-48bit-kernel.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Install / activate the 48-bit VA kernel on ONE Raspberry Pi node, safely.
+# Run from the workstation (needs: ssh to node, kubectl for drain/uncordon).
+#
+# Usage:
+#   install-48bit-kernel.sh <node> <tarball> stage      # copy kernel + modules onto node (no reboot)
+#   install-48bit-kernel.sh <node> <tarball> tryboot    # drain + ONE-SHOT boot the new kernel (falls back to stock on next reset)
+#   install-48bit-kernel.sh <node> <tarball> promote    # make kernel= permanent in config.txt + install apt guard + reboot + uncordon
+#   install-48bit-kernel.sh <node> <tarball> rollback   # remove kernel= line, reboot back onto stock kernel
+#
+# Safety model:
+# - tryboot.txt is honoured by the Pi firmware for exactly one boot attempt
+#   (`reboot '0 tryboot'`); any subsequent reset boots stock config.txt. So a
+#   broken kernel strands the node only until a power cycle, never permanently.
+# - CAUTION: if the trial kernel HANGS (rather than panics+reboots), the node
+#   needs a physical power cycle — drain first, canary on a worker, never start
+#   with kube-master.
+# - promote appends `kernel=kernel8-48bit.img` to config.txt. apt kernel
+#   updates keep writing kernel8.img (unused, harmless, and a always-fresh
+#   rollback target); they cannot touch our file.
+set -euo pipefail
+
+NODE="${1:?usage: $0 <node> <tarball> stage|tryboot|promote|rollback}"
+TARBALL="${2:?missing tarball}"
+ACTION="${3:?missing action: stage|tryboot|promote|rollback}"
+
+SSH=(ssh -o BatchMode=yes -o ConnectTimeout=5 "${NODE}")
+FW=/boot/firmware
+
+wait_for_ssh() {
+  local tries=60
+  echo "==> waiting for ${NODE} to come back (max $((tries*5))s)"
+  for _ in $(seq 1 "${tries}"); do
+    if ssh -o BatchMode=yes -o ConnectTimeout=3 "${NODE}" true 2>/dev/null; then return 0; fi
+    sleep 5
+  done
+  echo "FATAL: ${NODE} did not return; if the trial kernel hung, power-cycle it (stock kernel boots next)"; return 1
+}
+
+krel() { tar -xzOf "${TARBALL}" KERNEL_RELEASE; }
+
+case "${ACTION}" in
+stage)
+  KREL=$(krel)
+  echo "==> staging ${KREL} onto ${NODE}"
+  scp -q "${TARBALL}" "${NODE}:/tmp/k48.tar.gz"
+  "${SSH[@]}" "
+    set -euo pipefail
+    sudo tar -C / --no-same-owner -xzf /tmp/k48.tar.gz modules
+    sudo mv /modules/lib/modules/${KREL} /lib/modules/ 2>/dev/null || sudo rsync -a /modules/lib/modules/${KREL}/ /lib/modules/${KREL}/
+    sudo rm -rf /modules
+    tar -xzOf /tmp/k48.tar.gz boot/kernel8-48bit.img | sudo tee ${FW}/kernel8-48bit.img >/dev/null
+    rm /tmp/k48.tar.gz
+    echo staged: \$(ls -la ${FW}/kernel8-48bit.img); ls -d /lib/modules/${KREL}
+  "
+  ;;
+
+tryboot)
+  KREL=$(krel)
+  echo "==> drain ${NODE}"
+  kubectl drain "${NODE}" --ignore-daemonsets --delete-emptydir-data --timeout=120s
+  echo "==> one-shot tryboot of ${KREL} on ${NODE}"
+  "${SSH[@]}" "
+    set -euo pipefail
+    test -f ${FW}/kernel8-48bit.img
+    sudo cp ${FW}/config.txt ${FW}/tryboot.txt
+    echo 'kernel=kernel8-48bit.img' | sudo tee -a ${FW}/tryboot.txt >/dev/null
+    sudo reboot '0 tryboot'
+  " || true   # ssh drops on reboot
+  wait_for_ssh
+  GOT=$("${SSH[@]}" uname -r)
+  if [ "${GOT}" = "${KREL}" ]; then
+    echo "==> TRYBOOT OK: ${NODE} is running ${GOT} (one-shot; a plain reboot returns to stock)"
+  else
+    echo "FATAL: ${NODE} booted ${GOT}, expected ${KREL} — tryboot failed, node is on stock kernel"; exit 1
+  fi
+  ;;
+
+promote)
+  KREL=$(krel)
+  GOT=$("${SSH[@]}" uname -r)
+  [ "${GOT}" = "${KREL}" ] || { echo "FATAL: refusing to promote — ${NODE} is running ${GOT}, not ${KREL} (run tryboot first)"; exit 1; }
+  echo "==> promoting kernel= on ${NODE} + installing apt guard"
+  "${SSH[@]}" "
+    set -euo pipefail
+    grep -q '^kernel=kernel8-48bit.img' ${FW}/config.txt || echo 'kernel=kernel8-48bit.img' | sudo tee -a ${FW}/config.txt >/dev/null
+    sudo rm -f ${FW}/tryboot.txt
+    # Post-apt guard: warn loudly if the boot pin or the kernel file ever disappears.
+    printf 'DPkg::Post-Invoke { \"test -f ${FW}/kernel8-48bit.img && grep -q ^kernel=kernel8-48bit.img ${FW}/config.txt || echo \\\\\"WARNING: 48-bit kernel boot pin is BROKEN — Envoy will crash on this node after next reboot (see rpi-k3s tools/rpi-kernel-48bit)\\\\\" >&2\"; };\n' | sudo tee /etc/apt/apt.conf.d/99-48bit-kernel-guard >/dev/null
+    sudo reboot
+  " || true
+  wait_for_ssh
+  GOT=$("${SSH[@]}" uname -r)
+  [ "${GOT}" = "${KREL}" ] || { echo "FATAL: after promote, ${NODE} runs ${GOT}"; exit 1; }
+  kubectl uncordon "${NODE}"
+  echo "==> PROMOTED: ${NODE} permanently on ${KREL}; guard installed; node uncordoned"
+  ;;
+
+rollback)
+  echo "==> rolling ${NODE} back to stock kernel"
+  "${SSH[@]}" "
+    set -euo pipefail
+    sudo sed -i '/^kernel=kernel8-48bit.img/d' ${FW}/config.txt
+    sudo rm -f ${FW}/tryboot.txt /etc/apt/apt.conf.d/99-48bit-kernel-guard
+    sudo reboot
+  " || true
+  wait_for_ssh
+  echo "==> ${NODE} back on: $("${SSH[@]}" uname -r)"
+  kubectl uncordon "${NODE}" 2>/dev/null || true
+  ;;
+
+*) echo "unknown action ${ACTION}"; exit 2 ;;
+esac

--- a/tools/rpi-kernel-48bit/install-48bit-kernel.sh
+++ b/tools/rpi-kernel-48bit/install-48bit-kernel.sh
@@ -34,14 +34,35 @@ FINAL_IMG="kernel8-48bit.img"
 GUARD=/etc/apt/apt.conf.d/99-48bit-kernel-guard
 
 krel() { tar -xzOf "${TARBALL}" KERNEL_RELEASE; }
+# Marker = "<kernelrelease> <sha256-of-Image>" so two builds with the same
+# release string are still distinguishable across stage/tryboot/promote.
+marker_expected() {
+  printf '%s %s' "$(krel)" "$(tar -xzOf "${TARBALL}" boot/${FINAL_IMG} | sha256sum | cut -d' ' -f1)"
+}
 
 wait_for_down() {
   echo "==> waiting for ${NODE} to go DOWN (max 90s)"
+  local misses=0
   for _ in $(seq 1 18); do
-    if ! ssh -o BatchMode=yes -o ConnectTimeout=3 "${NODE}" true 2>/dev/null; then return 0; fi
+    if ! ssh -o BatchMode=yes -o ConnectTimeout=3 "${NODE}" true 2>/dev/null; then
+      misses=$((misses+1))
+      # two consecutive failed probes — a single blip can't fake a reboot
+      [ "${misses}" -ge 2 ] && return 0
+    else
+      misses=0
+    fi
     sleep 5
   done
   echo "FATAL: ${NODE} never went down — the reboot did not happen; investigate before retrying"; return 1
+}
+
+uncordon_with_retry() {
+  # After a kube-master reboot, ssh returns before the k3s API listens.
+  for _ in $(seq 1 12); do
+    if kubectl uncordon "${NODE}" 2>/dev/null; then return 0; fi
+    sleep 5
+  done
+  echo "WARN: could not uncordon ${NODE} (API not up?) — run: kubectl uncordon ${NODE}"; return 1
 }
 
 wait_for_up() {
@@ -76,6 +97,7 @@ drain_node() {
 case "${ACTION}" in
 stage)
   KREL=$(krel)
+  MARKER_EXPECTED=$(marker_expected)
   echo "==> staging ${KREL} onto ${NODE} (trial file — live kernel untouched)"
   scp -q "${TARBALL}" "${NODE}:/tmp/k48.tar.gz"
   "${SSH[@]}" "
@@ -86,7 +108,7 @@ stage)
     # Atomic-ish kernel write: temp file on the same FAT fs, then rename.
     tar -xzOf /tmp/k48.tar.gz boot/${FINAL_IMG} | sudo tee ${FW}/${TRIAL_IMG}.tmp >/dev/null
     sudo mv ${FW}/${TRIAL_IMG}.tmp ${FW}/${TRIAL_IMG}
-    printf '%s\n' '${KREL}' | sudo tee ${FW}/kernel8-48bit-trial.krel >/dev/null
+    printf '%s\n' '${MARKER_EXPECTED}' | sudo tee ${FW}/kernel8-48bit-trial.krel >/dev/null
     rm -rf /tmp/k48.tar.gz /tmp/k48-modules
     echo \"staged: \$(ls -la ${FW}/${TRIAL_IMG})\"
     ls -d /lib/modules/${KREL}
@@ -95,9 +117,10 @@ stage)
 
 tryboot)
   KREL=$(krel)
-  echo "==> pre-flight: trial marker must match this tarball"
+  MARKER_EXPECTED=$(marker_expected)
+  echo "==> pre-flight: trial marker (release + image sha) must match this tarball"
   MARKER=$("${SSH[@]}" "cat ${FW}/kernel8-48bit-trial.krel 2>/dev/null" || true)
-  [ "${MARKER}" = "${KREL}" ] || { echo "FATAL: staged trial is '${MARKER}', tarball is '${KREL}' — re-run stage"; exit 1; }
+  [ "${MARKER}" = "${MARKER_EXPECTED}" ] || { echo "FATAL: staged trial is '${MARKER}', tarball is '${MARKER_EXPECTED}' — re-run stage"; exit 1; }
   echo "==> writing tryboot.txt (one-shot) + ensuring panic=10 in cmdline.txt"
   "${SSH[@]}" "
     set -euo pipefail
@@ -124,8 +147,9 @@ promote)
   KREL=$(krel)
   GOT=$("${SSH[@]}" uname -r)
   [ "${GOT}" = "${KREL}" ] || { echo "FATAL: refusing to promote — ${NODE} runs ${GOT}, not ${KREL} (run tryboot first)"; exit 1; }
+  MARKER_EXPECTED=$(marker_expected)
   MARKER=$("${SSH[@]}" "cat ${FW}/kernel8-48bit-trial.krel 2>/dev/null" || true)
-  [ "${MARKER}" = "${KREL}" ] || { echo "FATAL: trial marker '${MARKER}' != '${KREL}' — trial was re-staged since tryboot"; exit 1; }
+  [ "${MARKER}" = "${MARKER_EXPECTED}" ] || { echo "FATAL: trial marker '${MARKER}' != '${MARKER_EXPECTED}' — trial was re-staged since tryboot"; exit 1; }
 
   echo "==> promoting: trial -> ${FINAL_IMG}, pin in config.txt (mutations, fully checked)"
   "${SSH[@]}" "
@@ -151,7 +175,7 @@ promote)
     grep -q '^kernel=${FINAL_IMG}' ${FW}/config.txt
     test -f ${GUARD} && sudo apt-get check -qq
   " || { echo "FATAL: post-promote verification failed on ${NODE} — node left cordoned"; exit 1; }
-  kubectl uncordon "${NODE}"
+  uncordon_with_retry
   echo "==> PROMOTED: ${NODE} permanently on ${KREL}; guard installed and apt-validated; node uncordoned"
   ;;
 
@@ -172,7 +196,7 @@ rollback)
     *-48bit*) echo "FATAL: ${NODE} still runs ${GOT} after rollback — investigate; node left cordoned"; exit 1 ;;
     *)        echo "==> ROLLBACK OK: ${NODE} on stock ${GOT}" ;;
   esac
-  kubectl uncordon "${NODE}"
+  uncordon_with_retry
   ;;
 
 *) echo "unknown action ${ACTION}"; exit 2 ;;


### PR DESCRIPTION
Tooling to restore the 48-bit VA kernels (Envoy TCMalloc requirement) durably — root-cause fix for the 2026-07-05 Envoy crashloop, per the researched plan.

**Mechanism:** custom kernel filename `kernel8-48bit.img` + `kernel=` pin in config.txt (apt cannot clobber a file it doesn't own — the 2026-03 build died because it overwrote `kernel8.img` in place) + a post-apt guard hook + tryboot one-shot safety for the first boot of each node.

Scripts are shellcheck-clean. Execution plan: build → canary worker1 (tryboot → validate with the envoy repro → promote) → roll worker2/3, kube-master last → then un-pin #49 in a follow-up PR.

Adversarial review requested before merge (bmad-code-review).