### PR TITLE
Bump quixit to v0.29.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.28.2 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.29.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Deploy quixit v0.29.0 — retro-console UI overhaul (AI-slop tells removed, Departure Mono headings, em411 pixel icons + credit, mobile-safe notifications toggle). quixit#155 / release ianhundere/quixit@v0.29.0.