### PR TITLE
Bump tufkin to v0.22.0

### DIFF
--- a/apps/tufkin/deployment.yml
+++ b/apps/tufkin/deployment.yml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-secret
       initContainers:
         - name: migrate
-          image: ghcr.io/ianhundere/tufkin:0.21.1 # {"$imagepolicy": "flux-system:tufkin"}
+          image: ghcr.io/ianhundere/tufkin:0.22.0 # {"$imagepolicy": "flux-system:tufkin"}
           command: ["/usr/local/bin/migrate"]
           args:
             - "-path"
@@ -38,7 +38,7 @@ spec:
                   key: db-password
       containers:
         - name: tufkin
-          image: ghcr.io/ianhundere/tufkin:0.21.1 # {"$imagepolicy": "flux-system:tufkin"}
+          image: ghcr.io/ianhundere/tufkin:0.22.0 # {"$imagepolicy": "flux-system:tufkin"}
           ports:
             - containerPort: 8080
           envFrom:


### PR DESCRIPTION
Deploy tufkin v0.22.0 — password self-service (change/forgot/reset endpoints + hosted reset page) and /api ContentType scoping. Fixes the change-password 406 incident. tufkin#116; migration 000013 applies via the migrate init-container.