### PR TITLE
chore(quixit): bump image to 0.29.3

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.29.2 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.29.3 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps quixit prod deployment 0.29.2 → 0.29.3 (image confirmed in GHCR). Source: quixit#162 / release v0.29.3 — deferred-work carryover sweep (audit-log/ratelimit/chat/activity hardening). No UI changes; Flux reconciles main → rolling deploy.