### PR TITLE
deploy(quixit): bump image to 0.30.0

### DIFF
--- a/apps/quixit/deployment.yml
+++ b/apps/quixit/deployment.yml
@@ -40,7 +40,7 @@ spec:
                   key: db-password
       containers:
         - name: quixit
-          image: ghcr.io/ianhundere/quixit:0.29.3 # {"$imagepolicy": "flux-system:quixit"}
+          image: ghcr.io/ianhundere/quixit:0.30.0 # {"$imagepolicy": "flux-system:quixit"}
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps `apps/quixit/deployment.yml` from 0.29.3 to 0.30.0 (quixit#164 submit-view redesign + voice sweep, quixit#165 postgres/doc follow-ups). Hold merge until the 0.30.0 image is confirmed on GHCR.